### PR TITLE
Disallow unused imports

### DIFF
--- a/NeutronStandard/Sniffs/Namespaces/DisallowUnusedImportSniff.php
+++ b/NeutronStandard/Sniffs/Namespaces/DisallowUnusedImportSniff.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NeutronStandard\Sniffs\Namespaces;
+
+use NeutronStandard\SniffHelpers;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class DisallowUnusedImportSniff implements Sniff {
+	public function register() {
+		return [T_USE];
+	}
+
+	public function process(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$semiPtr = $phpcsFile->findNext([T_SEMICOLON], $stackPtr + 1);
+		if (! $semiPtr) {
+			return;
+		}
+		$importNameToken = $tokens[$semiPtr - 1];
+		$importName = $importNameToken['content'];
+		// Check rest of file for importName
+		$secondImportNamePtr = $phpcsFile->findNext([T_STRING], $semiPtr + 1, null, false, $importName);
+		if (! $secondImportNamePtr) {
+			$error = 'Unused imports are not allowed';
+			$phpcsFile->addError($error, $stackPtr, 'UnusedImport');
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -316,3 +316,10 @@ For consistency, if we _do_ need to call a variable function, we might as well u
 
 - `call_user_func($f, $x, $y, $z)` is equal to `$f($x, $y, $z)`
 - `call_user_func_array($f, $args)` is equal to `$f(...$args)`
+
+## Imports
+
+**New code MUST NOT import a class, function, or constant without using that import.**
+
+It's easy when refactoring code to accidentally leave an unused import in a file.
+

--- a/tests/Sniffs/Namespaces/DisallowUnusedImportSniffTest.php
+++ b/tests/Sniffs/Namespaces/DisallowUnusedImportSniffTest.php
@@ -13,6 +13,6 @@ class DisallowUnusedImportSniffTest extends TestCase {
 		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
 		$phpcsFile->process();
 		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
-		$this->assertEquals([5, 7, 11, 13, 16], $lines);
+		$this->assertEquals([5, 7, 11, 13, 16, 19], $lines);
 	}
 }

--- a/tests/Sniffs/Namespaces/DisallowUnusedImportSniffTest.php
+++ b/tests/Sniffs/Namespaces/DisallowUnusedImportSniffTest.php
@@ -13,6 +13,6 @@ class DisallowUnusedImportSniffTest extends TestCase {
 		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
 		$phpcsFile->process();
 		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
-		$this->assertEquals([5, 7, 11, 13, 16, 19], $lines);
+		$this->assertEquals([5, 7, 11, 13, 16, 18, 20], $lines);
 	}
 }

--- a/tests/Sniffs/Namespaces/DisallowUnusedImportSniffTest.php
+++ b/tests/Sniffs/Namespaces/DisallowUnusedImportSniffTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandardTest;
+
+use PHPUnit\Framework\TestCase;
+
+class DisallowUnusedImportSniffTest extends TestCase {
+	public function testDisallowUnusedImports() {
+		$fixtureFile = __DIR__ . '/ImportFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Namespaces/DisallowUnusedImportSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
+		$this->assertEquals([5, 7, 11, 13, 16], $lines);
+	}
+}

--- a/tests/Sniffs/Namespaces/ImportFixture.php
+++ b/tests/Sniffs/Namespaces/ImportFixture.php
@@ -1,0 +1,21 @@
+<?php
+use My\Full\Classname;
+use My\Full\ClassnameTwo as AnotherClass;
+// The following line should report an unused import
+use My\Full\UnusedClass;
+// The following line should report an unused import
+use My\Full\UnusedClassTwo as AnotherUnusedClass;
+use function My\Full\functionName;
+use function My\Full\functionName as anotherFunction;
+// The following line should report an unused import
+use function My\Full\unusedFunctionName;
+// The following line should report an unused import
+use function My\Full\unusedFunctionNameTwo as anotherUnusedFunction;
+use const My\Full\MY_CONST;
+// The following line should report an unused import
+use const My\Full\UNUSED_CONST;
+
+new Classname();
+new AnotherClass();
+functionName();
+anotherFunction(MY_CONST);

--- a/tests/Sniffs/Namespaces/ImportFixture.php
+++ b/tests/Sniffs/Namespaces/ImportFixture.php
@@ -19,3 +19,4 @@ new Classname();
 new AnotherClass();
 functionName();
 anotherFunction(MY_CONST);
+anotherFunction('UNUSED_CONST');

--- a/tests/Sniffs/Namespaces/ImportFixture.php
+++ b/tests/Sniffs/Namespaces/ImportFixture.php
@@ -14,6 +14,7 @@ use function My\Full\unusedFunctionNameTwo as anotherUnusedFunction;
 use const My\Full\MY_CONST;
 // The following line should report an unused import
 use const My\Full\UNUSED_CONST;
+// The following line should report an unused import
 use First;
 // The following line should report an unused import
 use Second;

--- a/tests/Sniffs/Namespaces/ImportFixture.php
+++ b/tests/Sniffs/Namespaces/ImportFixture.php
@@ -14,9 +14,13 @@ use function My\Full\unusedFunctionNameTwo as anotherUnusedFunction;
 use const My\Full\MY_CONST;
 // The following line should report an unused import
 use const My\Full\UNUSED_CONST;
+use First;
+// The following line should report an unused import
+use Second;
 
 new Classname();
 new AnotherClass();
 functionName();
 anotherFunction(MY_CONST);
 anotherFunction('UNUSED_CONST');
+new \Third\Second\First();


### PR DESCRIPTION
Add a sniff that prevents `use` statements that import classes, functions, or constants which are not used.

For example, if I have the line `use My\Classname;` but `Classname` is not used anywhere in the file, this would trigger an error.

This adds the rule:

**New code MUST NOT import a class, function, or constant without using that import.**
