### PR TITLE
Discourage Variable Functions

### DIFF
--- a/NeutronStandard/Sniffs/Functions/DisallowCallUserFuncSniff.php
+++ b/NeutronStandard/Sniffs/Functions/DisallowCallUserFuncSniff.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace NeutronStandard\Sniffs\Functions;
+
+use NeutronStandard\SniffHelpers;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class DisallowCallUserFuncSniff implements Sniff {
+	public function register() {
+		return [T_STRING];
+	}
+
+	public function process(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$functionName = $tokens[$stackPtr]['content'];
+		$helper = new SniffHelpers();
+		$disallowedFunctions = [
+			'call_user_func',
+			'call_user_func_array',
+		];
+		if (in_array($functionName, $disallowedFunctions) && $helper->isFunctionCall($phpcsFile, $stackPtr)) {
+			$error = 'call_user_func and call_user_func_array are not allowed';
+			$phpcsFile->addError($error, $stackPtr, 'CallUserFunc');
+		}
+	}
+}

--- a/NeutronStandard/Sniffs/Functions/VariableFunctionsSniff.php
+++ b/NeutronStandard/Sniffs/Functions/VariableFunctionsSniff.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace NeutronStandard\Sniffs\Functions;
+
+use NeutronStandard\SniffHelpers;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class VariableFunctionsSniff implements Sniff {
+	public function register() {
+		return [T_VARIABLE];
+	}
+
+	public function process(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$nextNonWhitespacePtr = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, null, true, null, false);
+		if (! $nextNonWhitespacePtr) {
+			return;
+		}
+		if ($tokens[$nextNonWhitespacePtr]['code'] !== T_OPEN_PARENTHESIS) {
+			return;
+		}
+		$message = 'Variable functions are discouraged';
+		$phpcsFile->addWarning($message, $stackPtr, 'VariableFunction');
+	}
+}

--- a/README.md
+++ b/README.md
@@ -279,3 +279,29 @@ Instead, if a single function is used to instantiate a class (typically a static
 **New code MUST NOT have more than one adjacent blank line.**
 
 Whitespace is useful for separating logical sections of code, but excess whitespace takes up too much of the screen. One empty line is usually sufficient to separate sections of code.
+
+## Variable Functions
+
+**New code SHOULD NOT call Variable Functions.**
+
+**New code MUST NOT use call_user_func or call_user_func_array.**
+
+Having variable function names prevents easily tracing the usage and definition of a function. If a function signature needs to be changed or removed, for example, a developer would typically search the code base for uses of that function name. With variable functions, a function name could be created by joining strings together or otherwise manipulating a string, making it nearly impossible to find that use. Even if the string is unmodified, it may be defined somewhere far away from the place where it is called, again making it hard to trace its use. Lastly, with a function name as a string, it's possible for the string to be accidentally modified or to be set to something unexpected, potentially causing a fatal error.
+
+Instead, we can use a mapping function to transform a string into a hard-coded function call. For example, here are three ways to call the function stored in `$myFunction`; notice how the third option actually has the function name in the code where it is called.
+
+```php
+call_user_func($myFunction, 'hello');
+```
+
+```php
+$myFunction('hello');
+```
+
+```php
+switch($myFunction) {
+  case 'speak':
+    speak('hello');
+    break;
+}
+```

--- a/README.md
+++ b/README.md
@@ -290,13 +290,19 @@ Having variable function names prevents easily tracing the usage and definition 
 
 Instead, we can use a mapping function to transform a string into a hard-coded function call. For example, here are three ways to call the function stored in `$myFunction`; notice how the third option actually has the function name in the code where it is called.
 
+This one uses `call_user_func`.
+
 ```php
 call_user_func($myFunction, 'hello');
 ```
 
+The next one uses the new syntax.
+
 ```php
 $myFunction('hello');
 ```
+
+The following version actually does not call a variable function at all.
 
 ```php
 switch($myFunction) {
@@ -305,3 +311,8 @@ switch($myFunction) {
     break;
 }
 ```
+
+For consistency, if we _do_ need to call a variable function, we might as well use the newer version of the syntax.
+
+- `call_user_func($f, $x, $y, $z)` is equal to `$f($x, $y, $z)`
+- `call_user_func_array($f, $args)` is equal to `$f(...$args)`

--- a/tests/Sniffs/Functions/CallUserFuncFixture.php
+++ b/tests/Sniffs/Functions/CallUserFuncFixture.php
@@ -1,0 +1,12 @@
+<?php
+
+function doSomething($arg1, $arg2, $arg3) {
+}
+
+// Next line should report call_user_func is not allowed
+call_user_func('doSomething', 'foo', 'bar', 'baz');
+$args = ['foo', 'bar', 'baz'];
+// Next line should report call_user_func is not allowed
+call_user_func_array('doSomething', $args);
+doSomething('foo', 'bar', 'baz');
+doSomething(...$args);

--- a/tests/Sniffs/Functions/DisallowCallUserFuncSniffTest.php
+++ b/tests/Sniffs/Functions/DisallowCallUserFuncSniffTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandardTest;
+
+use PHPUnit\Framework\TestCase;
+
+class DisallowCallUserFuncSniffTest extends TestCase {
+	public function testDisallowCallUserFuncSniff() {
+		$fixtureFile = __DIR__ . '/CallUserFuncFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Functions/DisallowCallUserFuncSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
+		$this->assertEquals([7, 10], $lines);
+	}
+}

--- a/tests/Sniffs/Functions/VariableFunctionFixture.php
+++ b/tests/Sniffs/Functions/VariableFunctionFixture.php
@@ -1,0 +1,13 @@
+<?php
+
+function doSomething($arg1, $arg2, $arg3) {
+}
+
+$funcName = 'doSomething';
+// Next line should report variable functions are not allowed
+$funcName('foo', 'bar', 'baz');
+$args = ['foo', 'bar', 'baz'];
+// Next line should report variable functions are not allowed
+$funcName(...$args);
+doSomething('foo', 'bar', 'baz');
+doSomething(...$args);

--- a/tests/Sniffs/Functions/VariableFunctionsSniffTest.php
+++ b/tests/Sniffs/Functions/VariableFunctionsSniffTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandardTest;
+
+use PHPUnit\Framework\TestCase;
+
+class VariableFunctionsSniffTest extends TestCase {
+	public function testVariableFunctionsSniff() {
+		$fixtureFile = __DIR__ . '/VariableFunctionFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Functions/VariableFunctionsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$this->assertEquals([8, 11], $lines);
+	}
+}


### PR DESCRIPTION
This adds the following rules.

**New code SHOULD NOT call Variable Functions.**

**New code MUST NOT use call_user_func or call_user_func_array.**

Having variable function names prevents easily tracing the usage and definition of a function. If a function signature needs to be changed or removed, for example, a developer would typically search the code base for uses of that function name. With variable functions, a function name could be created by joining strings together or otherwise manipulating a string, making it nearly impossible to find that use. Even if the string is unmodified, it may be defined somewhere far away from the place where it is called, again making it hard to trace its use. Lastly, with a function name as a string, it's possible for the string to be accidentally modified or to be set to something unexpected, potentially causing a fatal error.

Instead, we can use a mapping function to transform a string into a hard-coded function call. For example, here are three ways to call the function stored in `$myFunction`; notice how the third option actually has the function name in the code where it is called.

This one uses `call_user_func`.

```php
call_user_func($myFunction, 'hello');
```

The next one uses the new syntax.

```php
$myFunction('hello');
```

The following version actually does not call a variable function at all.

```php
switch($myFunction) {
  case 'speak':
    speak('hello');
    break;
}
```

For consistency, if we _do_ need to call a variable function, we might as well use the newer version of the syntax.

- `call_user_func($f, $x, $y, $z)` is equal to `$f($x, $y, $z)`
- `call_user_func_array($f, $args)` is equal to `$f(...$args)`
