### PR TITLE
Disallow multiple blank adjacent lines

### DIFF
--- a/NeutronStandard/Sniffs/Whitespace/DisallowMultipleNewlinesSniff.php
+++ b/NeutronStandard/Sniffs/Whitespace/DisallowMultipleNewlinesSniff.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace NeutronStandard\Sniffs\Whitespace;
+
+use NeutronStandard\SniffHelpers;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class DisallowMultipleNewlinesSniff implements Sniff {
+	public function register() {
+		return [T_WHITESPACE];
+	}
+
+	public function process(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		if ($tokens[$stackPtr]['content'] !== "\n") {
+			return;
+		}
+		if ($stackPtr < 3) {
+			return;
+		}
+		if ($tokens[$stackPtr - 1]['content'] !== "\n") {
+			return;
+		}
+		if ($tokens[$stackPtr - 2]['content'] !== "\n") {
+			return;
+		}
+		$error = 'Multiple newlines are no allowed';
+		$phpcsFile->addError($error, $stackPtr, 'MultipleNewlines');
+	}
+}

--- a/README.md
+++ b/README.md
@@ -274,3 +274,8 @@ When a class is instantiated multiple places, it must have all its dependencies 
 
 Instead, if a single function is used to instantiate a class (typically a static function called a "factory"), then it becomes possible to just make the change in one place. If a new configuration of dependencies is desired, it's possible to just create a new factory.
 
+## Newlines
+
+**New code MUST NOT have more than one adjacent blank line.**
+
+Whitespace is useful for separating logical sections of code, but excess whitespace takes up too much of the screen. One empty line is usually sufficient to separate sections of code.

--- a/tests/Sniffs/Whitespace/DisallowMultipleNewlinesSniffTest.php
+++ b/tests/Sniffs/Whitespace/DisallowMultipleNewlinesSniffTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandardTest;
+
+use PHPUnit\Framework\TestCase;
+
+class DisallowMultipleNewlinesSniffTest extends TestCase {
+	public function testDisallowMultipleNewlinesSniff() {
+		$fixtureFile = __DIR__ . '/NoMultipleNewlinesFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Whitespace/DisallowMultipleNewlinesSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
+		$this->assertEquals([8, 15, 20], $lines);
+	}
+}

--- a/tests/Sniffs/Whitespace/NoMultipleNewlinesFixture.php
+++ b/tests/Sniffs/Whitespace/NoMultipleNewlinesFixture.php
@@ -1,0 +1,22 @@
+<?php
+
+function foo($arg1) {
+
+	echo $arg1;
+}
+
+
+// Previous line should report no multiple newlines
+function bar() {
+	foo();
+
+	$val1 = 'baz';
+
+
+	// Previous line should report no multiple newlines
+	$val2 = $val1 . 'foo';
+	foo($val2);
+
+
+	// Previous line should report no multiple newlines
+}


### PR DESCRIPTION
This adds the following rule.

**New code MUST NOT have more than one adjacent blank line.**