### PR TITLE
TypeHintSniff: allow array type hints

### DIFF
--- a/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
+++ b/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
@@ -20,12 +20,16 @@ class TypeHintSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$openParenPtr = $tokens[$stackPtr]['parenthesis_opener'];
 		$closeParenPtr = $tokens[$stackPtr]['parenthesis_closer'];
+		$hintTypes = [
+			T_STRING,
+			T_ARRAY_HINT,
+		];
 
 		for ($i = ($openParenPtr + 1); $i < $closeParenPtr; $i++) {
 			if ($tokens[$i]['code'] === T_VARIABLE) {
 				$tokenBeforePtr = $phpcsFile->findPrevious(T_WHITESPACE, $i - 1, $openParenPtr, true);
 				$tokenBefore = $tokens[$tokenBeforePtr];
-				if (! $tokenBeforePtr || $tokenBefore['code'] !== T_STRING) {
+				if (! $tokenBeforePtr || ! in_array($tokenBefore['code'], $hintTypes, true)) {
 					$error = 'Argument type is missing';
 					$phpcsFile->addWarning($error, $stackPtr, 'NoArgumentType');
 				}

--- a/tests/Sniffs/Functions/fixture.php
+++ b/tests/Sniffs/Functions/fixture.php
@@ -142,4 +142,20 @@ class MyClass {
 	public function hasHints(string $arg1): MyClass {
 		return new MyClass($arg1);
 	}
+
+	public function hasHintsWithArray(array $arg1): MyClass {
+		return new MyClass($arg1);
+	}
+
+	public function hasHintsWithInt(int $arg1): MyClass {
+		return new MyClass($arg1);
+	}
+
+	public function hasHintsWithBool(bool $arg1): MyClass {
+		return new MyClass($arg1);
+	}
+
+	public function hasHintsWithClass(MyClass $arg1): MyClass {
+		return new MyClass($arg1);
+	}
 }


### PR DESCRIPTION
To avoid being the same as the array keyword, it appears that the
`array` typehint does not tokenize as a `T_STRING` and instead is a
`T_ARRAY_HINT`.