### PR TITLE
Properly detect return type scopes in TypeHintSniff

### DIFF
--- a/tests/Sniffs/Functions/TypeHintSniffTest.php
+++ b/tests/Sniffs/Functions/TypeHintSniffTest.php
@@ -14,6 +14,6 @@ class TypeHintSniffTest extends TestCase {
 		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
-		$this->assertEquals([118, 123, 128, 133], $lines);
+		$this->assertEquals([118, 123, 128, 133, 139, 145, 159], $lines);
 	}
 }

--- a/tests/Sniffs/Functions/fixture.php
+++ b/tests/Sniffs/Functions/fixture.php
@@ -134,6 +134,31 @@ class MyClass {
 		return $arg1 . ' yolo' . $arg2;
 	}
 
+	public function hasClosureWithReturnAndNoHint() {
+		// Next line should warn about no type hint
+		$myFunc = function() {
+			return true;
+		};
+	}
+
+	// Next line should warn about no type hint
+	public function hasNoReturnHintAndClosure() {
+		$myFunc = function() {
+			'foobar';
+		};
+		return true;
+	}
+
+	public function hasClosureWithReturn() {
+		$myFunc = function() : bool {
+			return true;
+		};
+	}
+
+	// Next line should warn about unused type hint
+	public function hasReturnHintButNoReturn() : string {
+	}
+
 	public function hasNoReturn(string $arg1, string $arg2) {
 		$arg1;
 		$arg2;


### PR DESCRIPTION
Fixes #7 and also adds a new warning for when there is a return type but no return.