### PR TITLE
Allow callable type hints

### DIFF
--- a/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
+++ b/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
@@ -23,6 +23,8 @@ class TypeHintSniff implements Sniff {
 		$hintTypes = [
 			T_STRING,
 			T_ARRAY_HINT,
+			T_CALLABLE,
+			T_SELF,
 		];
 
 		for ($i = ($openParenPtr + 1); $i < $closeParenPtr; $i++) {

--- a/tests/Sniffs/Functions/fixture.php
+++ b/tests/Sniffs/Functions/fixture.php
@@ -168,16 +168,32 @@ class MyClass {
 		return new MyClass($arg1);
 	}
 
-	public function hasHintsWithArray(array $arg1): MyClass {
-		return new MyClass($arg1);
+	public function hasHintsWithArray(array $arg1): array {
+		return [$arg1];
 	}
 
-	public function hasHintsWithInt(int $arg1): MyClass {
-		return new MyClass($arg1);
+	public function hasHintsWithInt(int $arg1): int {
+		return $arg1;
 	}
 
-	public function hasHintsWithBool(bool $arg1): MyClass {
-		return new MyClass($arg1);
+	public function hasHintsWithBool(bool $arg1): bool {
+		return $arg1 && true;
+	}
+
+	public function hasHintsWithSelf(self $arg1): self {
+		return $arg1;
+	}
+
+	public function hasHintsWithCallable(callable $arg1): callable {
+		return $arg1;
+	}
+
+	public function hasHintsWithIterable(iterable $arg1): iterable {
+		return [$arg1];
+	}
+
+	public function hasHintsWithFloat(float $arg1): float {
+		return $arg1;
 	}
 
 	public function hasHintsWithClass(MyClass $arg1): MyClass {


### PR DESCRIPTION
Fixes #10 and adds tests for [all of the possible type hints](http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration) so hopefully this won't happen any more.