### PR TITLE
Add auto-fix for DisallowLongformArraySniff

### DIFF
--- a/NeutronStandard/Sniffs/Arrays/DisallowLongformArraySniff.php
+++ b/NeutronStandard/Sniffs/Arrays/DisallowLongformArraySniff.php
@@ -17,7 +17,21 @@ class DisallowLongformArraySniff implements Sniff {
 		$helper = new SniffHelpers();
 		if ($functionName === 'array' && $helper->isFunctionCall($phpcsFile, $stackPtr)) {
 			$error = 'Longform array is not allowed';
-			$phpcsFile->addError($error, $stackPtr, 'LongformArray');
+			$shouldFix = $phpcsFile->addFixableError($error, $stackPtr, 'LongformArray');
+			if ($shouldFix) {
+				$this->fixTokens($phpcsFile, $stackPtr);
+			}
 		}
+	}
+
+	private function fixTokens(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$openParenPtr = $tokens[$stackPtr]['parenthesis_opener'];
+		$closeParenPtr = $tokens[$stackPtr]['parenthesis_closer'];
+		$phpcsFile->fixer->beginChangeset();
+		$phpcsFile->fixer->replaceToken($stackPtr, '');
+		$phpcsFile->fixer->replaceToken($openParenPtr, '[');
+		$phpcsFile->fixer->replaceToken($closeParenPtr, ']');
+		$phpcsFile->fixer->endChangeset();
 	}
 }

--- a/tests/SniffTestHelper.php
+++ b/tests/SniffTestHelper.php
@@ -30,4 +30,10 @@ class SniffTestHelper {
 	public function getErrorLineNumbersFromFile(LocalFile $phpcsFile): array {
 		return $this->getLineNumbersFromMessages($phpcsFile->getErrors());
 	}
+
+	public function getFixedFileContents(LocalFile $phpcsFile) {
+		$phpcsFile->fixer->startFile($phpcsFile);
+		$phpcsFile->fixer->fixFile();
+		return $phpcsFile->fixer->getContents();
+	}
 }

--- a/tests/Sniffs/Arrays/DisallowLongformArraySniffTest.php
+++ b/tests/Sniffs/Arrays/DisallowLongformArraySniffTest.php
@@ -16,4 +16,20 @@ class DisallowLongformArraySniffTest extends TestCase {
 		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([5], $lines);
 	}
+
+	public function testFixDisallowLongFormArraySniff() {
+		$fixtureFile = __DIR__ . '/fixture.php';
+		$fixedFixtureFile = __DIR__ . '/fixedLongFormArrayFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Arrays/DisallowLongformArraySniff.php';
+
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$phpcsFile->fixer->startFile($phpcsFile);
+		$result = $phpcsFile->fixer->fixFile();
+		$this->assertTrue($result);
+		$fixedContents = file_get_contents($fixedFixtureFile);
+		$actualContents = $phpcsFile->fixer->getContents();
+		$this->assertEquals($fixedContents, $actualContents);
+	}
 }

--- a/tests/Sniffs/Arrays/DisallowLongformArraySniffTest.php
+++ b/tests/Sniffs/Arrays/DisallowLongformArraySniffTest.php
@@ -25,11 +25,8 @@ class DisallowLongformArraySniffTest extends TestCase {
 		$helper = new SniffTestHelper();
 		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
 		$phpcsFile->process();
-		$phpcsFile->fixer->startFile($phpcsFile);
-		$result = $phpcsFile->fixer->fixFile();
-		$this->assertTrue($result);
+		$actualContents = $helper->getFixedFileContents($phpcsFile);
 		$fixedContents = file_get_contents($fixedFixtureFile);
-		$actualContents = $phpcsFile->fixer->getContents();
 		$this->assertEquals($fixedContents, $actualContents);
 	}
 }

--- a/tests/Sniffs/Arrays/fixedLongFormArrayFixture.php
+++ b/tests/Sniffs/Arrays/fixedLongFormArrayFixture.php
@@ -1,0 +1,8 @@
+<?php
+class MyClass {
+	public function doSomething() {
+		// Next line should report no long arrays allowed
+		$rest = ['x' => 'y'];
+		$rest;
+	}
+}


### PR DESCRIPTION
Now it's possible to automatically fix `DisallowLongformArraySniff` errors. That is, if you run `phpcbf` on a file, it will automatically convert `array( 1, 2 )` to `[ 1, 2 ]`).