### PR TITLE
 RequireStrictTypesSniff: skip parsing comment blocks entirely

### DIFF
--- a/NeutronStandard/Sniffs/StrictTypes/RequireStrictTypesSniff.php
+++ b/NeutronStandard/Sniffs/StrictTypes/RequireStrictTypesSniff.php
@@ -39,11 +39,6 @@ class RequireStrictTypesSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$ignoredTokenTypes = [
 			T_WHITESPACE,
-			T_DOC_COMMENT_OPEN_TAG,
-			T_DOC_COMMENT_WHITESPACE,
-			T_DOC_COMMENT_STAR,
-			T_DOC_COMMENT_STRING,
-			T_DOC_COMMENT_CLOSE_TAG,
 		];
 		$skipExpressionTokenTypes = [
 			T_USE,
@@ -57,6 +52,10 @@ class RequireStrictTypesSniff implements Sniff {
 			}
 			if ($token['code'] === T_INTERFACE) {
 				$ptr = $this->getEndOfBlockPtr($phpcsFile, $ptr);
+				continue;
+			}
+			if (isset($token['comment_closer'])) {
+				$ptr = $token['comment_closer'];
 				continue;
 			}
 			if (in_array($token['code'], $skipExpressionTokenTypes)) {

--- a/tests/Sniffs/StrictTypes/InterfaceOnlyFixture.php
+++ b/tests/Sniffs/StrictTypes/InterfaceOnlyFixture.php
@@ -6,6 +6,7 @@ use Brain\Nonces\NonceInterface;
 
 /**
  * Interface SettingsPageAuthInterface
+ * @package Just\Some\Test\Auth
  */
 interface SettingsPageAuthInterface {
 	/**

--- a/tests/Sniffs/StrictTypes/interfaceOnlyFixture.php
+++ b/tests/Sniffs/StrictTypes/interfaceOnlyFixture.php
@@ -6,6 +6,7 @@ use Brain\Nonces\NonceInterface;
 
 /**
  * Interface SettingsPageAuthInterface
+ * @package Just\Some\Test\Auth
  */
 interface SettingsPageAuthInterface {
 	/**


### PR DESCRIPTION
Fixes #29 (again)