### PR TITLE
DisallowGlobalFunctionsSniff: allow global functions in a namespace

### DIFF
--- a/NeutronStandard/Sniffs/Globals/DisallowGlobalFunctionsSniff.php
+++ b/NeutronStandard/Sniffs/Globals/DisallowGlobalFunctionsSniff.php
@@ -13,7 +13,11 @@ class DisallowGlobalFunctionsSniff implements Sniff {
 	public function process(File $phpcsFile, $stackPtr) {
 		$tokens = $phpcsFile->getTokens();
 		$currentToken = $tokens[$stackPtr];
+		$namespaceTokenPtr = $phpcsFile->findPrevious(T_NAMESPACE, $stackPtr);
 		if (! empty($currentToken['conditions'])) {
+			return;
+		}
+		if ($namespaceTokenPtr) {
 			return;
 		}
 		$error = 'Global functions are not allowed';

--- a/tests/Sniffs/Globals/DisallowGlobalFunctionsSniffTest.php
+++ b/tests/Sniffs/Globals/DisallowGlobalFunctionsSniffTest.php
@@ -16,4 +16,15 @@ class DisallowGlobalFunctionsSniffTest extends TestCase {
 		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([3], $lines);
 	}
+
+	public function testDisallowGlobalFunctionsSniffAllowsNamespacedGlobals() {
+		$fixtureFile = __DIR__ . '/NamespacedGlobalFunctionsFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Globals/DisallowGlobalFunctionsSniff.php';
+
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
+		$this->assertEquals([], $lines);
+	}
 }

--- a/tests/Sniffs/Globals/NamespacedGlobalFunctionsFixture.php
+++ b/tests/Sniffs/Globals/NamespacedGlobalFunctionsFixture.php
@@ -1,0 +1,14 @@
+<?php
+namespace Foo\Bar;
+
+function test() {
+	define("FOO", "bar");
+}
+
+class MyClass {
+	public function notTooLong() {
+		$foo = 'bar';
+		$foo;
+		$foo; // Hello
+	}
+}


### PR DESCRIPTION
Fixes #35 