### PR TITLE
RequireStrictTypesSniff: Ignore comments detecting interface-only files

### DIFF
--- a/NeutronStandard/Sniffs/StrictTypes/RequireStrictTypesSniff.php
+++ b/NeutronStandard/Sniffs/StrictTypes/RequireStrictTypesSniff.php
@@ -39,6 +39,7 @@ class RequireStrictTypesSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$ignoredTokenTypes = [
 			T_WHITESPACE,
+			T_COMMENT,
 		];
 		$skipExpressionTokenTypes = [
 			T_USE,


### PR DESCRIPTION
Fixes #29 