### PR TITLE
Add an isset to getEndOfFunctionPtr

### DIFF
--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -74,7 +74,7 @@ class SniffHelpers {
 	public function getEndOfFunctionPtr(File $phpcsFile, $stackPtr) {
 		$tokens = $phpcsFile->getTokens();
 		$openFunctionBracketPtr = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, $stackPtr + 1);
-		return $openFunctionBracketPtr
+		return $openFunctionBracketPtr && isset($tokens[$openFunctionBracketPtr]['bracket_closer'])
 			? $tokens[$openFunctionBracketPtr]['bracket_closer']
 			: $this->getNextSemicolonPtr($phpcsFile, $stackPtr);
 	}


### PR DESCRIPTION
This is just a bit more defensive coding. I'm not sure what situation triggers this, but I've seen it happen when running phpcbf.