### PR TITLE
Add RequireParenthesisSpacingSniff

### DIFF
--- a/NeutronStandard/Sniffs/Whitespace/RequireParenthesisSpacingSniff.php
+++ b/NeutronStandard/Sniffs/Whitespace/RequireParenthesisSpacingSniff.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace NeutronStandard\Sniffs\Whitespace;
+
+use NeutronStandard\SniffHelpers;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class RequireParenthesisSpacingSniff implements Sniff {
+	public function register() {
+		return [T_OPEN_PARENTHESIS, T_CLOSE_PARENTHESIS];
+	}
+
+	public function process(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$isBefore = ($token['type'] === 'T_OPEN_PARENTHESIS');
+		$nextTokenPtr = $isBefore ? $stackPtr + 1 : $stackPtr - 1;
+		$nextToken = $tokens[$nextTokenPtr];
+		if (! isset($nextToken['type'])) {
+			return;
+		}
+		$allowedTypes = ['T_WHITESPACE'];
+		$allowedTypes[] = $isBefore ? 'T_CLOSE_PARENTHESIS' : 'T_OPEN_PARENTHESIS';
+		if (in_array($nextToken['type'], $allowedTypes, true)) {
+			return;
+		}
+		$error = 'Parenthesis content must be padded by a space';
+		$shouldFix = $phpcsFile->addFixableError($error, $stackPtr, 'Missing');
+		if ($shouldFix) {
+			$this->fixTokens($phpcsFile, $nextTokenPtr, $isBefore);
+		}
+	}
+
+	private function fixTokens(File $phpcsFile, $stackPtr, $isBefore) {
+		$phpcsFile->fixer->beginChangeset();
+		if ($isBefore) {
+			$phpcsFile->fixer->addContentBefore($stackPtr, ' ');
+		} else {
+			$phpcsFile->fixer->addContent($stackPtr, ' ');
+		}
+		$phpcsFile->fixer->endChangeset();
+	}
+}

--- a/tests/Sniffs/Whitespace/FixedParenthesisSpacingFixture.php
+++ b/tests/Sniffs/Whitespace/FixedParenthesisSpacingFixture.php
@@ -1,0 +1,31 @@
+<?php
+
+function doSomething( $arg1 ) {
+	doSomethingElse( $arg1 );
+	doSomethingElse( $arg1 );
+	doSomethingElse( $arg1 );
+	doSomethingElse( $arg1 );
+}
+
+function doSomethingElse( $arg1 ) {
+	if ( ! isset( $arg1 ) ) {
+		$arg1 = 'go';
+	}
+	if ( ! isset( $arg1 ) ) {
+		$arg1 = 'go';
+	}
+	if ( ! isset( $arg1 ) ) {
+		$arg1 = 'go';
+	}
+	if ( ! isset( $arg1 ) ) {
+		$arg1 = 'go';
+	}
+	$val1 = ( $arg1 === 'go' ) ? 'foo' : 'bar';
+	$val1 = ( $arg1 === 'go' ) ? 'foo' : 'bar';
+	$val1 = ( $arg1 === 'go' ) ? 'foo' : 'bar';
+	$val1 = ( $arg1 === 'go' ) ? 'foo' : 'bar';
+	doManyArgs( $arg1, $val1, $val2 );
+	doManyArgs( $arg1, $val1, $val2 );
+	doManyArgs( $arg1, $val1, $val2 );
+	doManyArgs( $arg1, $val1, $val2 );
+}

--- a/tests/Sniffs/Whitespace/ParenthesisSpacingFixture.php
+++ b/tests/Sniffs/Whitespace/ParenthesisSpacingFixture.php
@@ -1,0 +1,31 @@
+<?php
+
+function doSomething( $arg1 ) {
+	doSomethingElse( $arg1 );
+	doSomethingElse($arg1);
+	doSomethingElse( $arg1);
+	doSomethingElse($arg1 );
+}
+
+function doSomethingElse( $arg1 ) {
+	if (! isset($arg1)) {
+		$arg1 = 'go';
+	}
+	if (! isset( $arg1)) {
+		$arg1 = 'go';
+	}
+	if (! isset($arg1 )) {
+		$arg1 = 'go';
+	}
+	if ( ! isset($arg1 )) {
+		$arg1 = 'go';
+	}
+	$val1 = ( $arg1 === 'go' ) ? 'foo' : 'bar';
+	$val1 = ($arg1 === 'go') ? 'foo' : 'bar';
+	$val1 = ( $arg1 === 'go') ? 'foo' : 'bar';
+	$val1 = ($arg1 === 'go' ) ? 'foo' : 'bar';
+	doManyArgs( $arg1, $val1, $val2 );
+	doManyArgs($arg1, $val1, $val2);
+	doManyArgs( $arg1, $val1, $val2);
+	doManyArgs($arg1, $val1, $val2 );
+}

--- a/tests/Sniffs/Whitespace/RequireParenthesisSpacingSniffTest.php
+++ b/tests/Sniffs/Whitespace/RequireParenthesisSpacingSniffTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandardTest;
+
+use PHPUnit\Framework\TestCase;
+
+class RequireParenthesisSpacingSniffTest extends TestCase {
+	public function testRequireNewlineBetweenFunctionsSniff() {
+		$fixtureFile = __DIR__ . '/ParenthesisSpacingFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Whitespace/RequireParenthesisSpacingSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getErrorLineNumbersFromFile($phpcsFile);
+		$this->assertEquals([5, 6, 7, 11, 14, 17, 20, 24, 25, 26, 28, 29, 30], $lines);
+	}
+
+	public function testFixRequireNewlineBetweenFunctionsSniff() {
+		$fixtureFile = __DIR__ . '/ParenthesisSpacingFixture.php';
+		$fixedFixtureFile = __DIR__ . '/FixedParenthesisSpacingFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Whitespace/RequireParenthesisSpacingSniff.php';
+
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$actualContents = $helper->getFixedFileContents($phpcsFile);
+		$fixedContents = file_get_contents($fixedFixtureFile);
+		$this->assertEquals($fixedContents, $actualContents);
+	}
+}


### PR DESCRIPTION
This adds a sniff that implements the WordPress standard of spacing inside parenthesis:

```php
if ( $foo ) {
  doSomething( $foo );
}
```

It can also fix instances where spaces need to be added.

Fixes #50  
