### PR TITLE
Add RequireImportsSniff

### DIFF
--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -184,19 +184,27 @@ class SniffHelpers {
 		if (! $nextStringOrBracketPtr || ! isset($tokens[$nextStringOrBracketPtr])) {
 			return [];
 		}
+		if (in_array($tokens[$nextStringOrBracketPtr]['content'], ['function', 'const'])) {
+			$nextStringOrBracketPtr = $phpcsFile->findNext([T_STRING, T_OPEN_USE_GROUP], $nextStringOrBracketPtr + 1);
+			if (! $nextStringOrBracketPtr || ! isset($tokens[$nextStringOrBracketPtr])) {
+				return [];
+			}
+		}
 		if ($tokens[$nextStringOrBracketPtr]['type'] === 'T_OPEN_USE_GROUP') {
-			$endBracketPtr = $phpcsFile->findNext([T_CLOSE_USE_GROUP], $nextStringOrBracketPtr + 1);
+			$nextBracketPtr = $nextStringOrBracketPtr;
+			$endBracketPtr = $phpcsFile->findNext([T_CLOSE_USE_GROUP], $nextBracketPtr + 1);
 			if (! $endBracketPtr) {
 				return [];
 			}
-			return $this->getAllStringsBefore($phpcsFile, $nextStringOrBracketPtr + 1, $endBracketPtr);
+			return $this->getAllStringsBefore($phpcsFile, $nextBracketPtr + 1, $endBracketPtr);
 		}
-		$endOfStatementPtr = $phpcsFile->findNext([T_SEMICOLON], $nextStringOrBracketPtr + 1);
-		$nextSeparatorPtr = $phpcsFile->findNext([T_NS_SEPARATOR], $nextStringOrBracketPtr + 1, $endOfStatementPtr);
+		$nextStringPtr = $nextStringOrBracketPtr;
+		$endOfStatementPtr = $phpcsFile->findNext([T_SEMICOLON], $nextStringPtr + 1);
+		$nextSeparatorPtr = $phpcsFile->findNext([T_NS_SEPARATOR], $nextStringPtr + 1, $endOfStatementPtr);
 		if ($nextSeparatorPtr) {
 			return $this->getImportNames($phpcsFile, $nextSeparatorPtr);
 		}
-		return [$tokens[$nextStringOrBracketPtr]['content']];
+		return [$tokens[$nextStringPtr]['content']];
 	}
 
 	public function getAllStringsBefore(File $phpcsFile, int $startPtr, int $endPtr): array {

--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -21,6 +21,62 @@ class SniffHelpers {
 		return true;
 	}
 
+	public function isMethodCall(File $phpcsFile, $stackPtr) {
+		if (! $this->isFunctionCall($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		$tokens = $phpcsFile->getTokens();
+		$prevPtr = $phpcsFile->findPrevious([T_OBJECT_OPERATOR], $stackPtr - 1, $stackPtr - 2);
+		if ($prevPtr && isset($tokens[$prevPtr])) {
+			return true;
+		}
+		return false;
+	}
+
+	public function isPropertyAccess(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$prevPtr = $phpcsFile->findPrevious([T_OBJECT_OPERATOR], $stackPtr - 1, $stackPtr - 2);
+		if ($prevPtr && isset($tokens[$prevPtr])) {
+			return true;
+		}
+		return false;
+	}
+
+	public function isObjectInstantiation(File $phpcsFile, $stackPtr) {
+		if (! $this->isFunctionCall($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		$tokens = $phpcsFile->getTokens();
+		$prevPtr = $phpcsFile->findPrevious([T_NEW], $stackPtr - 1, $stackPtr - 2);
+		if ($prevPtr && isset($tokens[$prevPtr])) {
+			return true;
+		}
+		return false;
+	}
+
+	// Borrowed this idea from https://pear.php.net/reference/PHP_CodeSniffer-3.1.1/apidoc/PHP_CodeSniffer/LowercasePHPFunctionsSniff.html
+	public function isBuiltInFunction(File $phpcsFile, $stackPtr) {
+		$allFunctions = get_defined_functions();
+		$builtInFunctions = array_flip($allFunctions['internal']);
+		$tokens = $phpcsFile->getTokens();
+		$functionName = $tokens[$stackPtr]['content'];
+		return isset($builtInFunctions[strtolower($functionName)]);
+	}
+
+	public function isPredefinedConstant(File $phpcsFile, $stackPtr) {
+		$allConstants = get_defined_constants();
+		$tokens = $phpcsFile->getTokens();
+		$constantName = $tokens[$stackPtr]['content'];
+		return isset($allConstants[$constantName]);
+	}
+
+	public function isPredefinedClass(File $phpcsFile, $stackPtr) {
+		$allClasses = get_declared_classes();
+		$tokens = $phpcsFile->getTokens();
+		$className = $tokens[$stackPtr]['content'];
+		return in_array($className, $allClasses);
+	}
+
 	// From https://stackoverflow.com/questions/619610/whats-the-most-efficient-test-of-whether-a-php-string-ends-with-another-string
 	public function doesStringEndWith(string $string, string $test): bool {
 		$strlen = strlen($string);
@@ -104,5 +160,156 @@ class SniffHelpers {
 			return true;
 		}
 		return ! $openFunctionBracketPtr;
+	}
+
+	public function getImportType(File $phpcsFile, $stackPtr): string {
+		$tokens = $phpcsFile->getTokens();
+		$nextStringPtr = $phpcsFile->findNext([T_STRING], $stackPtr + 1);
+		if (! $nextStringPtr) {
+			return 'unknown';
+		}
+		$nextString = $tokens[$nextStringPtr];
+		if ($nextString['content'] === 'function') {
+			return 'function';
+		}
+		if ($nextString['content'] === 'const') {
+			return 'const';
+		}
+		return 'class';
+	}
+
+	public function getImportNames(File $phpcsFile, $stackPtr): array {
+		$tokens = $phpcsFile->getTokens();
+		$nextStringOrBracketPtr = $phpcsFile->findNext([T_STRING, T_OPEN_USE_GROUP], $stackPtr + 1);
+		if (! $nextStringOrBracketPtr || ! isset($tokens[$nextStringOrBracketPtr])) {
+			return [];
+		}
+		if ($tokens[$nextStringOrBracketPtr]['type'] === 'T_OPEN_USE_GROUP') {
+			$endBracketPtr = $phpcsFile->findNext([T_CLOSE_USE_GROUP], $nextStringOrBracketPtr + 1);
+			if (! $endBracketPtr) {
+				return [];
+			}
+			return $this->getAllStringsBefore($phpcsFile, $nextStringOrBracketPtr + 1, $endBracketPtr);
+		}
+		$endOfStatementPtr = $phpcsFile->findNext([T_SEMICOLON], $nextStringOrBracketPtr + 1);
+		$nextSeparatorPtr = $phpcsFile->findNext([T_NS_SEPARATOR], $nextStringOrBracketPtr + 1, $endOfStatementPtr);
+		if ($nextSeparatorPtr) {
+			return $this->getImportNames($phpcsFile, $nextSeparatorPtr);
+		}
+		return [$tokens[$nextStringOrBracketPtr]['content']];
+	}
+
+	public function getAllStringsBefore(File $phpcsFile, int $startPtr, int $endPtr): array {
+		$tokens = $phpcsFile->getTokens();
+		$strings = [];
+		$nextStringPtr = $phpcsFile->findNext([T_STRING], $startPtr);
+		while ($nextStringPtr < $endPtr) {
+			if (! $nextStringPtr || ! isset($tokens[$nextStringPtr])) {
+				break;
+			}
+			$nextString = $tokens[$nextStringPtr];
+			$strings[] = $nextString['content'];
+			$nextStringPtr = $phpcsFile->findNext([T_STRING], $nextStringPtr + 1);
+		}
+		return $strings;
+	}
+
+	public function isClass(File $phpcsFile, $stackPtr): bool {
+		$nextSeparatorPtr = $phpcsFile->findNext([T_NS_SEPARATOR], $stackPtr + 1, $stackPtr + 2);
+		if ($nextSeparatorPtr) {
+			return false;
+		}
+		$prevSeparatorPtr = $phpcsFile->findPrevious([T_NS_SEPARATOR], $stackPtr - 1, $stackPtr - 2);
+		if ($prevSeparatorPtr) {
+			return false;
+		}
+		$previousStatementPtr = $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET], $stackPtr - 1);
+		if (! $previousStatementPtr) {
+			$previousStatementPtr = 1;
+		}
+		if ($this->isConstant($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		if ($this->isMethodCall($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		if ($this->isPropertyAccess($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		if ($this->isBuiltInFunction($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		$prevUsePtr = $phpcsFile->findPrevious([T_USE, T_CONST, T_FUNCTION], $stackPtr - 1, $previousStatementPtr);
+		if ($prevUsePtr) {
+			return false;
+		}
+		return true;
+	}
+
+	public function isConstant(File $phpcsFile, $stackPtr): bool {
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$stringName = $token['content'];
+		if (strtoupper($stringName) !== $stringName) {
+			return false;
+		}
+		$nextSeparatorPtr = $phpcsFile->findNext([T_NS_SEPARATOR], $stackPtr + 1, $stackPtr + 2);
+		if ($nextSeparatorPtr) {
+			return false;
+		}
+		$prevSeparatorPtr = $phpcsFile->findPrevious([T_NS_SEPARATOR], $stackPtr - 1, $stackPtr - 2);
+		if ($prevSeparatorPtr) {
+			return false;
+		}
+		$previousStatementPtr = $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET], $stackPtr - 1);
+		if (! $previousStatementPtr) {
+			$previousStatementPtr = 1;
+		}
+		$prevUsePtr = $phpcsFile->findPrevious([T_USE], $stackPtr - 1, $previousStatementPtr);
+		if ($prevUsePtr) {
+			return false;
+		}
+		return true;
+	}
+
+	public function isConstantDefinition(File $phpcsFile, $stackPtr): bool {
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$prevNonWhitespacePtr = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, $stackPtr - 3, true, null, false);
+		if (! $prevNonWhitespacePtr || ! isset($tokens[$prevNonWhitespacePtr])) {
+			return false;
+		}
+		$prevToken = $tokens[$prevNonWhitespacePtr];
+		if ($prevToken['content'] === 'const') {
+			return true;
+		}
+		return false;
+	}
+
+	public function getConstantName(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$nextStringPtr = $phpcsFile->findNext([T_STRING], $stackPtr + 1, $stackPtr + 3);
+		if (! $nextStringPtr || ! isset($tokens[$nextStringPtr])) {
+			return null;
+		}
+		return $tokens[$nextStringPtr]['content'];
+	}
+
+	public function isStaticFunctionCall(File $phpcsFile, $stackPtr): bool {
+		return (bool) $this->getStaticPropertyClass($phpcsFile, $stackPtr);
+	}
+
+	public function getStaticPropertyClass(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		if (isset($tokens[$stackPtr - 1]['type']) && $tokens[$stackPtr - 1]['type'] === 'T_DOUBLE_COLON' && isset($tokens[$stackPtr - 2]['content'])) {
+			return $tokens[$stackPtr - 2]['content'];
+		}
+		return null;
+	}
+
+	public function isFunctionAMethod(File $phpcsFile, $stackPtr): bool {
+		$tokens = $phpcsFile->getTokens();
+		$currentToken = $tokens[$stackPtr];
+		return ! empty($currentToken['conditions']);
 	}
 }

--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -253,13 +253,13 @@ class SniffHelpers {
 		if ($nextSeparatorPtr) {
 			return false;
 		}
-		$prevSeparatorPtr = $phpcsFile->findPrevious([T_NS_SEPARATOR], $stackPtr - 1, $stackPtr - 2);
-		if ($prevSeparatorPtr) {
-			return false;
-		}
 		$previousStatementPtr = $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET], $stackPtr - 1);
 		if (! $previousStatementPtr) {
 			$previousStatementPtr = 1;
+		}
+		$isUseOrNamespace = $phpcsFile->findPrevious([T_USE, T_NAMESPACE], $stackPtr - 1, $previousStatementPtr);
+		if ($isUseOrNamespace) {
+			return false;
 		}
 		if ($this->isConstant($phpcsFile, $stackPtr)) {
 			return false;
@@ -291,13 +291,13 @@ class SniffHelpers {
 		if ($nextSeparatorPtr) {
 			return false;
 		}
-		$prevSeparatorPtr = $phpcsFile->findPrevious([T_NS_SEPARATOR], $stackPtr - 1, $stackPtr - 2);
-		if ($prevSeparatorPtr) {
-			return false;
-		}
 		$previousStatementPtr = $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET], $stackPtr - 1);
 		if (! $previousStatementPtr) {
 			$previousStatementPtr = 1;
+		}
+		$isUseOrNamespace = $phpcsFile->findPrevious([T_USE, T_NAMESPACE], $stackPtr - 1, $previousStatementPtr);
+		if ($isUseOrNamespace) {
+			return false;
 		}
 		$prevUsePtr = $phpcsFile->findPrevious([T_USE], $stackPtr - 1, $previousStatementPtr);
 		if ($prevUsePtr) {

--- a/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
+++ b/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
@@ -87,8 +87,8 @@ class RequireImportsSniff implements Sniff {
 	}
 
 	private function hasNamespace(File $phpcsFile, int $stackPtr): bool {
-		$startOfStatementPtr = $phpcsFile->findPrevious([T_SEMICOLON], $stackPtr);
-		return !! $phpcsFile->findPrevious([T_NS_SEPARATOR], $stackPtr, $startOfStatementPtr);
+		$tokens = $phpcsFile->getTokens();
+		return isset($tokens[$stackPtr - 1]) && $tokens[$stackPtr - 1]['type'] === 'T_NS_SEPARATOR';
 	}
 
 	private function processStaticFunctionCall(File $phpcsFile, $stackPtr) {

--- a/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
+++ b/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
@@ -7,12 +7,151 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
 class RequireImportsSniff implements Sniff {
+	private $importedFunctions = [];
+	private $importedConsts = [];
+	private $importedClasses = [];
+
 	public function register() {
-		return [];
+		return [T_USE, T_STRING];
 	}
 
 	public function process(File $phpcsFile, $stackPtr) {
-		$error = 'Function imports must be explicitly imported';
-		$phpcsFile->addError($error, $stackPtr, 'Function');
+		$helper = new SniffHelpers();
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		if ($token['type'] === 'T_USE') {
+			return $this->processUse($phpcsFile, $stackPtr);
+		}
+		if ($helper->isStaticFunctionCall($phpcsFile, $stackPtr)) {
+			return $this->processStaticFunctionCall($phpcsFile, $stackPtr);
+		}
+		if ($helper->isFunctionCall($phpcsFile, $stackPtr) && ! $helper->isMethodCall($phpcsFile, $stackPtr) && ! $helper->isBuiltInFunction($phpcsFile, $stackPtr) && ! $helper->isObjectInstantiation($phpcsFile, $stackPtr)) {
+			return $this->processFunctionCall($phpcsFile, $stackPtr);
+		}
+		if ($helper->isConstant($phpcsFile, $stackPtr) && ! $helper->isConstantDefinition($phpcsFile, $stackPtr) && ! $helper->isPredefinedConstant($phpcsFile, $stackPtr)) {
+			$this->processConstant($phpcsFile, $stackPtr);
+		}
+		if ($helper->isClass($phpcsFile, $stackPtr) && ! $helper->isPredefinedClass($phpcsFile, $stackPtr) && ! $helper->isPredefinedConstant($phpcsFile, $stackPtr)) {
+			$this->processClass($phpcsFile, $stackPtr);
+		}
+	}
+
+	private function processClass($phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$className = $token['content'];
+		if (! $this->isClassImported($className) && ! $this->isClassDefined($phpcsFile, $className)) {
+			$error = "Classes must be explicitly imported. Found '{$className}'.";
+			$phpcsFile->addWarning($error, $stackPtr, 'Class');
+		}
+	}
+
+	private function processConstant($phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$constantName = $token['content'];
+		if (! $this->isConstImported($constantName) && ! $this->isConstDefined($phpcsFile, $constantName)) {
+			$error = "Constants must be explicitly imported. Found '{$constantName}'.";
+			$phpcsFile->addWarning($error, $stackPtr, 'Constant');
+		}
+	}
+
+	private function processStaticFunctionCall(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$className = $helper->getStaticPropertyClass($phpcsFile, $stackPtr);
+		if (! $this->isClassImported($className)) {
+			$error = "Classes must be explicitly imported. Found '{$className}'.";
+			$phpcsFile->addWarning($error, $stackPtr, 'Class');
+		}
+	}
+
+	private function processFunctionCall(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$functionName = $token['content'];
+		if (! $this->isFunctionImported($functionName) && ! $this->isFunctionDefined($phpcsFile, $functionName)) {
+			$error = "Functions must be explicitly imported. Found '{$functionName}'.";
+			$phpcsFile->addWarning($error, $stackPtr, 'Function');
+		}
+	}
+
+	private function processUse(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$importType = $helper->getImportType($phpcsFile, $stackPtr);
+		switch ($importType) {
+			case 'function':
+				return $this->saveFunctionImport($phpcsFile, $stackPtr);
+			case 'const':
+				return $this->saveConstImport($phpcsFile, $stackPtr);
+			case 'class':
+				return $this->saveClassImport($phpcsFile, $stackPtr);
+		}
+	}
+
+	private function saveFunctionImport(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$importNames = $helper->getImportNames($phpcsFile, $stackPtr);
+		$this->importedFunctions = array_merge($this->importedFunctions, $importNames);
+	}
+
+	private function saveConstImport(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$importNames = $helper->getImportNames($phpcsFile, $stackPtr);
+		$this->importedConsts = array_merge($this->importedConsts, $importNames);
+	}
+
+	private function saveClassImport(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$importNames = $helper->getImportNames($phpcsFile, $stackPtr);
+		$this->importedClasses = array_merge($this->importedClasses, $importNames);
+	}
+
+	private function isFunctionImported(string $functionName): bool {
+		return in_array($functionName, $this->importedFunctions);
+	}
+
+	private function isConstImported(string $constName): bool {
+		return in_array($constName, $this->importedConsts);
+	}
+
+	private function isClassImported(string $name): bool {
+		return in_array($name, $this->importedClasses);
+	}
+
+	private function isClassDefined(File $phpcsFile, string $className): bool {
+		$classPtr = $phpcsFile->findNext([T_CLASS], 0);
+		while ($classPtr) {
+			$thisClassName = $phpcsFile->getDeclarationName($classPtr);
+			if ($className === $thisClassName) {
+				return true;
+			}
+			$classPtr = $phpcsFile->findNext([T_CLASS], $classPtr + 1);
+		}
+		return false;
+	}
+
+	private function isFunctionDefined(File $phpcsFile, string $functionName): bool {
+		$functionPtr = $phpcsFile->findNext([T_FUNCTION], 0);
+		while ($functionPtr) {
+			$thisFunctionName = $phpcsFile->getDeclarationName($functionPtr);
+			if ($functionName === $thisFunctionName) {
+				return true;
+			}
+			$functionPtr = $phpcsFile->findNext([T_FUNCTION], $functionPtr + 1);
+		}
+		return false;
+	}
+
+	private function isConstDefined(File $phpcsFile, string $functionName): bool {
+		$helper = new SniffHelpers();
+		$functionPtr = $phpcsFile->findNext([T_CONST], 0);
+		while ($functionPtr) {
+			$thisFunctionName = $helper->getConstantName($phpcsFile, $functionPtr);
+			if ($functionName === $thisFunctionName) {
+				return true;
+			}
+			$functionPtr = $phpcsFile->findNext([T_CONST], $functionPtr + 1);
+		}
+		return false;
 	}
 }

--- a/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
+++ b/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
@@ -59,7 +59,10 @@ class RequireImportsSniff implements Sniff {
 	}
 
 	private function markAbsoluteViolation(File $phpcsFile, int $stackPtr) {
-		$error = "Absolute symbols are not allowed; Import the symbol instead.";
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$symbolName = $token['content'];
+		$error = "Absolute symbols are not allowed; Import the symbol instead. Found '{$symbolName}'.";
 		$phpcsFile->addWarning($error, $stackPtr, 'Absolute');
 	}
 

--- a/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
+++ b/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NeutronStandard\Sniffs\Imports;
+
+use NeutronStandard\SniffHelpers;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class RequireImportsSniff implements Sniff {
+	public function register() {
+		return [];
+	}
+
+	public function process(File $phpcsFile, $stackPtr) {
+		$error = 'Function imports must be explicitly imported';
+		$phpcsFile->addError($error, $stackPtr, 'Function');
+	}
+}

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -48,6 +48,8 @@ class Car {
 			return new DrivingProblem('no speed limit');
 		}
 		setMoving(TYPE, true);
+		// next line has an explicit namespace call
+		\Physics\setMoving(TYPE, 'drive');
 		startMonitor();
 		$data = new stdClass(PHP_VERSION);
 		$store = new WeatherStore($data);

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -4,6 +4,7 @@ namespace CAR_APP\Vehicles;
 
 use Physics\MovementType;
 use function Roads\getSpeedLimit;
+use function monitor_begin;
 use function Physics\{
 	setMoving,
 	setStopped
@@ -59,4 +60,5 @@ class Car {
 function startMonitor() {
 	new Car();
 	echo str_replace('Foo', 'Bar', 'Foobar...');
+	monitor_begin();
 }

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -63,7 +63,7 @@ class Car {
 		try {
 			$store->trackWeather($store->key);
 			// next line has an explicit namespace call
-		} catch (\Exception $err) {
+		} catch (\MyException $err) {
 			return new Exception('buggy');
 		}
 		$name = $store->current_name_as_string;

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -16,6 +16,7 @@ use WeatherStore;
 use WeatherModels\Storm;
 use const Weather\SNOW;
 use const Weather\{RAIN, SLEET, CAR_IN_WEATHER};
+use Exception;
 
 const TYPE = 'Car';
 
@@ -39,7 +40,7 @@ class Car {
 			}
 		}
 		if ($currentWeather instanceof Storm) {
-			return false;
+			return new Exception('stormy');
 		}
 		// next line has unimported class
 		if ($currentWeather instanceof Drizzle) {
@@ -59,7 +60,11 @@ class Car {
 		$this->polluter = new PollutionProducer();
 		$data = new stdClass(PHP_VERSION);
 		$store = new WeatherStore($data);
-		$store->trackWeather($store->key);
+		try {
+			$store->trackWeather($store->key);
+		} catch (Exception $err) {
+			return new Exception('buggy');
+		}
 		$name = $store->current_name_as_string;
 		return new MovementType('driving in ' . $name);
 	}

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -52,6 +52,8 @@ class Car {
 		setMoving(TYPE, true);
 		// next line has an explicit namespace call
 		\Physics\setMoving(TYPE, 'drive');
+		// next line has an unimported function
+		setMovable(CAR_IN_WEATHER);
 		makeItMove(CAR_IN_WEATHER);
 		startMonitor();
 		$this->polluter = new PollutionProducer();

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -62,7 +62,8 @@ class Car {
 		$store = new WeatherStore($data);
 		try {
 			$store->trackWeather($store->key);
-		} catch (Exception $err) {
+			// next line has an explicit namespace call
+		} catch (\Exception $err) {
 			return new Exception('buggy');
 		}
 		$name = $store->current_name_as_string;

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -8,13 +8,14 @@ use function Roads\getSpeedLimit;
 use function monitor_begin;
 use function Physics\{
 	setMoving,
+	setMovable as makeItMove,
 	setStopped
 };
 use CAR_APP_GLOBALS;
 use WeatherStore;
 use WeatherModels\Storm;
 use const Weather\SNOW;
-use const Weather\{RAIN};
+use const Weather\{RAIN, SLEET, CAR_IN_WEATHER};
 
 const TYPE = 'Car';
 
@@ -51,6 +52,7 @@ class Car {
 		setMoving(TYPE, true);
 		// next line has an explicit namespace call
 		\Physics\setMoving(TYPE, 'drive');
+		makeItMove(CAR_IN_WEATHER);
 		startMonitor();
 		$this->polluter = new PollutionProducer();
 		$data = new stdClass(PHP_VERSION);

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace CAR_APP\Vehicles;
+
+use Physics\MovementType;
+use function Roads\getSpeedLimit;
+use function Physics\{
+	setMoving,
+	setStopped
+};
+use CAR_APP_GLOBALS;
+use WeatherStore;
+use WeatherModels\Storm;
+use const Weather\SNOW;
+use const Weather\{RAIN};
+
+const TYPE = 'Car';
+
+class Car {
+	public function drive() {
+		// next line has unimported function
+		$currentWeather = getWeather();
+		if ($currentWeather === SNOW) {
+			// next line has unimported class
+			return new DrivingProblem('weather is too harsh');
+		}
+		if ($currentWeather === RAIN) {
+			// next line has unimported class
+			return new DrivingProblem('weather is too harsh');
+		}
+		// next line has unimported const
+		if ($currentWeather === SUN) {
+			// next line has unimported class
+			if (DataStore::readyToMark()) {
+				WeatherStore::markGoodDay();
+			}
+		}
+		if ($currentWeather instanceof Storm) {
+			return false;
+		}
+		// next line has unimported class
+		if ($currentWeather instanceof Drizzle) {
+			throw new Exception();
+		}
+		if (getSpeedLimit() < 1) {
+			// next line has unimported class
+			return new DrivingProblem('no speed limit');
+		}
+		setMoving(TYPE, true);
+		startMonitor();
+		$data = new stdClass(PHP_VERSION);
+		$store = new WeatherStore($data);
+		$store->trackWeather($store->key);
+		$name = $store->current_name_as_string;
+		return new MovementType('driving in ' . $name);
+	}
+}
+
+function startMonitor() {
+	new Car();
+	echo str_replace('Foo', 'Bar', 'Foobar...');
+}

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -3,6 +3,7 @@
 namespace CAR_APP\Vehicles;
 
 use Physics\MovementType;
+use VehicleWithEmissions as PollutionProducer;
 use function Roads\getSpeedLimit;
 use function monitor_begin;
 use function Physics\{
@@ -51,6 +52,7 @@ class Car {
 		// next line has an explicit namespace call
 		\Physics\setMoving(TYPE, 'drive');
 		startMonitor();
+		$this->polluter = new PollutionProducer();
 		$data = new stdClass(PHP_VERSION);
 		$store = new WeatherStore($data);
 		$store->trackWeather($store->key);

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -23,6 +23,7 @@ class RequireImportsSniffTest extends TestCase {
 			51,
 			55,
 			57,
+			66,
 		], $lines);
 	}
 }

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -21,6 +21,7 @@ class RequireImportsSniffTest extends TestCase {
 			35,
 			43,
 			48,
+			52,
 		], $lines);
 	}
 }

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandardTest;
+
+use PHPUnit\Framework\TestCase;
+
+class RequireImportsSniffTest extends TestCase {
+	public function testRequireImportsSniff() {
+		$fixtureFile = __DIR__ . '/RequireImportsFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$this->assertEquals([
+			22,
+			25,
+			29,
+			32,
+			34,
+			42,
+			47,
+		], $lines);
+	}
+}

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -14,14 +14,14 @@ class RequireImportsSniffTest extends TestCase {
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([
-			24,
-			27,
-			31,
-			34,
-			36,
-			44,
-			49,
-			53,
+			25,
+			28,
+			32,
+			35,
+			37,
+			45,
+			50,
+			54,
 		], $lines);
 	}
 }

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -22,6 +22,7 @@ class RequireImportsSniffTest extends TestCase {
 			45,
 			50,
 			54,
+			56,
 		], $lines);
 	}
 }

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -14,15 +14,15 @@ class RequireImportsSniffTest extends TestCase {
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([
-			25,
-			28,
-			32,
-			35,
-			37,
-			45,
-			50,
-			54,
-			56,
+			26,
+			29,
+			33,
+			36,
+			38,
+			46,
+			51,
+			55,
+			57,
 		], $lines);
 	}
 }

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -14,13 +14,13 @@ class RequireImportsSniffTest extends TestCase {
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([
-			22,
-			25,
-			29,
-			32,
-			34,
-			42,
-			47,
+			23,
+			26,
+			30,
+			33,
+			35,
+			43,
+			48,
 		], $lines);
 	}
 }

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -14,14 +14,14 @@ class RequireImportsSniffTest extends TestCase {
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([
-			23,
-			26,
-			30,
-			33,
-			35,
-			43,
-			48,
-			52,
+			24,
+			27,
+			31,
+			34,
+			36,
+			44,
+			49,
+			53,
 		], $lines);
 	}
 }


### PR DESCRIPTION
This sniff requires that all functions, constants, and classes be imported explicitly and marks a warning if an unimported symbol is found.

That is, you cannot just import a namespace or assume that the symbols you use are in your namespace or the global namespace, each dependency must be explicitly imported. This makes dependency trees more clear.

For example:

```php
namespace Vehicles;
use function Vehicles\startCar;
class Car {
  public function drive() {
    startCar();
    goFaster(); // this will be a warning because `goFaster` was not imported
  }
}
```

Fixes #45 

Questions: 

- This will always add a warning for `define()` constants since they are never imported. Is there a way to tell the difference between a `const` constant and a `define` one? I don't think so.
- When used in WordPress this could be really annoying since it doesn't know any of the hundreds of WordPress symbols (`do_action()`, `is_wp_error()`, `WP_Error`, `mysql2date()`, etc.)
- Functions like `array_map()` [require the fully qualified namespace](https://blog.josephscott.org/2014/08/28/php-array_map-callback-expects-the-full-namespace/), so they're likely to trigger this warning a lot.