### PR TITLE
Add RequireImportsSniff (take 2)

### DIFF
--- a/NeutronStandard/ImportedSymbol.php
+++ b/NeutronStandard/ImportedSymbol.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandard;
+
+class ImportedSymbol {
+	private $ptr;
+	private $symbolName;
+	private $used;
+
+	public function __construct(int $stackPtr, string $symbolName) {
+		$this->ptr = $stackPtr;
+		$this->symbolName = $symbolName;
+		$this->used = false;
+	}
+
+	public function markUsed() {
+		$this->used = true;
+	}
+
+	public function isUsed(): bool {
+		return $this->used;
+	}
+
+	public function getName(): string {
+		return $this->symbolName;
+	}
+
+	public function getPtr(): int {
+		return $this->ptr;
+	}
+}

--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -198,6 +198,10 @@ class SniffHelpers {
 		if (! $nextStringPtr) {
 			return 'unknown';
 		}
+		$isClosureImport = $phpcsFile->findNext([T_OPEN_PARENTHESIS], $stackPtr + 1, $nextStringPtr);
+		if ($isClosureImport) {
+			return 'closure';
+		}
 		$nextString = $tokens[$nextStringPtr];
 		if ($nextString['content'] === 'function') {
 			return 'function';

--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace NeutronStandard;
 
+use NeutronStandard\Symbol;
 use PHP_CodeSniffer\Files\File;
 
 class SniffHelpers {
@@ -19,6 +20,91 @@ class SniffHelpers {
 			return false;
 		}
 		return true;
+	}
+
+	public function isObjectReference(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$prevPtr = $phpcsFile->findPrevious([T_OBJECT_OPERATOR], $stackPtr - 1, $stackPtr - 2);
+		return ($prevPtr && isset($tokens[$prevPtr]));
+	}
+
+	public function isStaticReference(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$prevPtr = $phpcsFile->findPrevious([T_DOUBLE_COLON], $stackPtr - 1, $stackPtr - 2);
+		return ($prevPtr && isset($tokens[$prevPtr]));
+	}
+
+	public function isMethodCall(File $phpcsFile, $stackPtr) {
+		if (! $this->isFunctionCall($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		$tokens = $phpcsFile->getTokens();
+		$prevPtr = $phpcsFile->findPrevious([T_OBJECT_OPERATOR], $stackPtr - 1, $stackPtr - 2);
+		if ($prevPtr && isset($tokens[$prevPtr])) {
+			return true;
+		}
+		return false;
+	}
+
+	public function isPropertyAccess(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$prevPtr = $phpcsFile->findPrevious([T_OBJECT_OPERATOR], $stackPtr - 1, $stackPtr - 2);
+		if ($prevPtr && isset($tokens[$prevPtr])) {
+			return true;
+		}
+		return false;
+	}
+
+	public function isObjectInstantiation(File $phpcsFile, $stackPtr) {
+		if (! $this->isFunctionCall($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		$tokens = $phpcsFile->getTokens();
+		$prevPtr = $phpcsFile->findPrevious([T_NEW], $stackPtr - 1, $stackPtr - 2);
+		if ($prevPtr && isset($tokens[$prevPtr])) {
+			return true;
+		}
+		return false;
+	}
+
+	// Borrowed this idea from https://pear.php.net/reference/PHP_CodeSniffer-3.1.1/apidoc/PHP_CodeSniffer/LowercasePHPFunctionsSniff.html
+	public function isBuiltInFunction(File $phpcsFile, $stackPtr) {
+		$allFunctions = get_defined_functions();
+		$builtInFunctions = array_flip($allFunctions['internal']);
+		$tokens = $phpcsFile->getTokens();
+		$functionName = $tokens[$stackPtr]['content'];
+		return isset($builtInFunctions[strtolower($functionName)]);
+	}
+
+	public function isPredefinedTypehint(File $phpcsFile, $stackPtr) {
+		$allTypehints = [
+			'bool',
+			'string',
+			'int',
+			'float',
+			'void',
+			'self',
+			'array',
+			'callable',
+			'iterable',
+		];
+		$tokens = $phpcsFile->getTokens();
+		$tokenContent = $tokens[$stackPtr]['content'];
+		return in_array($tokenContent, $allTypehints, true);
+	}
+
+	public function isPredefinedConstant(File $phpcsFile, $stackPtr) {
+		$allConstants = get_defined_constants();
+		$tokens = $phpcsFile->getTokens();
+		$constantName = $tokens[$stackPtr]['content'];
+		return isset($allConstants[$constantName]);
+	}
+
+	public function isPredefinedClass(File $phpcsFile, $stackPtr) {
+		$allClasses = get_declared_classes();
+		$tokens = $phpcsFile->getTokens();
+		$className = $tokens[$stackPtr]['content'];
+		return in_array($className, $allClasses);
 	}
 
 	// From https://stackoverflow.com/questions/619610/whats-the-most-efficient-test-of-whether-a-php-string-ends-with-another-string
@@ -104,5 +190,269 @@ class SniffHelpers {
 			return true;
 		}
 		return ! $openFunctionBracketPtr;
+	}
+
+	public function getImportType(File $phpcsFile, $stackPtr): string {
+		$tokens = $phpcsFile->getTokens();
+		$nextStringPtr = $phpcsFile->findNext([T_STRING], $stackPtr + 1);
+		if (! $nextStringPtr) {
+			return 'unknown';
+		}
+		$nextString = $tokens[$nextStringPtr];
+		if ($nextString['content'] === 'function') {
+			return 'function';
+		}
+		if ($nextString['content'] === 'const') {
+			return 'const';
+		}
+		return 'class';
+	}
+
+	private function getImportNamesFromGroup(File $phpcsFile, int $stackPtr): array {
+		$tokens = $phpcsFile->getTokens();
+		$endBracketPtr = $phpcsFile->findNext([T_CLOSE_USE_GROUP], $stackPtr + 1);
+		if (! $endBracketPtr) {
+			return [];
+		}
+		$lastImportPtr = $stackPtr;
+		$collectedSymbols = [];
+		$isLastImport = false;
+		while (! $isLastImport) {
+			$nextEndOfImportPtr = $phpcsFile->findNext([T_COMMA], $lastImportPtr + 1, $endBracketPtr);
+			if (! $nextEndOfImportPtr) {
+				$isLastImport = true;
+				$nextEndOfImportPtr = $endBracketPtr;
+			}
+			$lastStringPtr = $phpcsFile->findPrevious([T_STRING], $nextEndOfImportPtr - 1, $stackPtr);
+			if (! $lastStringPtr || ! isset($tokens[$lastStringPtr])) {
+				break;
+			}
+			$collectedSymbols[] = $tokens[$lastStringPtr]['content'];
+			$lastImportPtr = $nextEndOfImportPtr;
+		}
+		return $collectedSymbols;
+	}
+
+	public function getImportNames(File $phpcsFile, $stackPtr): array {
+		$tokens = $phpcsFile->getTokens();
+
+		$endOfStatementPtr = $phpcsFile->findNext([T_SEMICOLON], $stackPtr + 1);
+		if (! $endOfStatementPtr) {
+			return [];
+		}
+
+		// Process grouped imports differently
+		$nextBracketPtr = $phpcsFile->findNext([T_OPEN_USE_GROUP], $stackPtr + 1, $endOfStatementPtr);
+		if ($nextBracketPtr) {
+			return $this->getImportNamesFromGroup($phpcsFile, $nextBracketPtr);
+		}
+
+		// Get the last string before the last semicolon, comma, or closing curly bracket
+		$endOfImportPtr = $phpcsFile->findPrevious(
+			[T_COMMA, T_CLOSE_USE_GROUP],
+			$stackPtr + 1,
+			$endOfStatementPtr
+		);
+		if (! $endOfImportPtr) {
+			$endOfImportPtr = $endOfStatementPtr;
+		}
+		$lastStringPtr = $phpcsFile->findPrevious([T_STRING], $endOfImportPtr - 1, $stackPtr);
+		if (! $lastStringPtr || ! isset($tokens[$lastStringPtr])) {
+			return [];
+		}
+		return [$tokens[$lastStringPtr]['content']];
+	}
+
+	public function getAllStringsBefore(File $phpcsFile, int $startPtr, int $endPtr): array {
+		$tokens = $phpcsFile->getTokens();
+		$strings = [];
+		$nextStringPtr = $phpcsFile->findNext([T_STRING], $startPtr);
+		while ($nextStringPtr < $endPtr) {
+			if (! $nextStringPtr || ! isset($tokens[$nextStringPtr])) {
+				break;
+			}
+			$nextString = $tokens[$nextStringPtr];
+			$strings[] = $nextString['content'];
+			$nextStringPtr = $phpcsFile->findNext([T_STRING], $nextStringPtr + 1);
+		}
+		return $strings;
+	}
+
+	public function getPreviousStatementPtr(File $phpcsFile, int $stackPtr): int {
+		return $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET], $stackPtr - 1) ?: 1;
+	}
+
+	public function isWithinDeclareCall(File $phpcsFile, $stackPtr): bool {
+		$previousStatementPtr = $this->getPreviousStatementPtr($phpcsFile, $stackPtr);
+		return !! $phpcsFile->findPrevious([T_DECLARE], $stackPtr - 1, $previousStatementPtr);
+	}
+
+	public function isWithinDefineCall(File $phpcsFile, $stackPtr): bool {
+		$previousStatementPtr = $this->getPreviousStatementPtr($phpcsFile, $stackPtr);
+		return !! $phpcsFile->findPrevious([T_STRING], $stackPtr - 1, $previousStatementPtr, false, 'define');
+	}
+
+	public function isWithinNamespaceStatement(File $phpcsFile, $stackPtr): bool {
+		$previousStatementPtr = $this->getPreviousStatementPtr($phpcsFile, $stackPtr);
+		return !! $phpcsFile->findPrevious([T_NAMESPACE], $stackPtr - 1, $previousStatementPtr);
+	}
+
+	public function isWithinUseStatement(File $phpcsFile, $stackPtr): bool {
+		$previousStatementPtr = $this->getPreviousStatementPtr($phpcsFile, $stackPtr);
+		return !! $phpcsFile->findPrevious([T_USE], $stackPtr - 1, $previousStatementPtr);
+	}
+
+	public function isClass(File $phpcsFile, $stackPtr): bool {
+		$nextSeparatorPtr = $phpcsFile->findNext([T_NS_SEPARATOR], $stackPtr + 1, $stackPtr + 2);
+		if ($nextSeparatorPtr) {
+			return false;
+		}
+		$previousStatementPtr = $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET], $stackPtr - 1);
+		if (! $previousStatementPtr) {
+			$previousStatementPtr = 1;
+		}
+		$isUseOrNamespace = $phpcsFile->findPrevious([T_USE, T_NAMESPACE], $stackPtr - 1, $previousStatementPtr);
+		if ($isUseOrNamespace) {
+			return false;
+		}
+		if ($this->isConstant($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		if ($this->isMethodCall($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		if ($this->isPropertyAccess($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		if ($this->isBuiltInFunction($phpcsFile, $stackPtr)) {
+			return false;
+		}
+		$prevUsePtr = $phpcsFile->findPrevious([T_USE, T_CONST, T_FUNCTION], $stackPtr - 1, $previousStatementPtr);
+		if ($prevUsePtr) {
+			return false;
+		}
+		return true;
+	}
+
+	public function isConstant(File $phpcsFile, $stackPtr): bool {
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		$stringName = $token['content'];
+		if (strtoupper($stringName) !== $stringName) {
+			return false;
+		}
+		$nextSeparatorPtr = $phpcsFile->findNext([T_NS_SEPARATOR], $stackPtr + 1, $stackPtr + 2);
+		if ($nextSeparatorPtr) {
+			return false;
+		}
+		$previousStatementPtr = $phpcsFile->findPrevious([T_SEMICOLON, T_CLOSE_CURLY_BRACKET], $stackPtr - 1);
+		if (! $previousStatementPtr) {
+			$previousStatementPtr = 1;
+		}
+		$isUseOrNamespace = $phpcsFile->findPrevious([T_USE, T_NAMESPACE], $stackPtr - 1, $previousStatementPtr);
+		if ($isUseOrNamespace) {
+			return false;
+		}
+		$prevUsePtr = $phpcsFile->findPrevious([T_USE], $stackPtr - 1, $previousStatementPtr);
+		if ($prevUsePtr) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @return array|null
+	 */
+	public function getPreviousNonWhitespaceToken(File $phpcsFile, int $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$prevNonWhitespacePtr = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, $stackPtr - 3, true, null, false);
+		if (! $prevNonWhitespacePtr || ! isset($tokens[$prevNonWhitespacePtr])) {
+			return null;
+		}
+		return $tokens[$prevNonWhitespacePtr];
+	}
+
+	public function isConstantDefinition(File $phpcsFile, $stackPtr): bool {
+		$tokens = $phpcsFile->getTokens();
+		$prevNonWhitespacePtr = $phpcsFile->findPrevious(T_WHITESPACE, $stackPtr - 1, $stackPtr - 3, true, null, false);
+		if (! $prevNonWhitespacePtr || ! isset($tokens[$prevNonWhitespacePtr])) {
+			return false;
+		}
+		$prevToken = $tokens[$prevNonWhitespacePtr];
+		if ($prevToken['content'] === 'const') {
+			return true;
+		}
+		return false;
+	}
+
+	public function getConstantName(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		$nextStringPtr = $phpcsFile->findNext([T_STRING], $stackPtr + 1, $stackPtr + 3);
+		if (! $nextStringPtr || ! isset($tokens[$nextStringPtr])) {
+			return null;
+		}
+		return $tokens[$nextStringPtr]['content'];
+	}
+
+	public function isStaticFunctionCall(File $phpcsFile, $stackPtr): bool {
+		return (bool) $this->getStaticPropertyClass($phpcsFile, $stackPtr);
+	}
+
+	public function getStaticPropertyClass(File $phpcsFile, $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		if (isset($tokens[$stackPtr - 1]['type']) && $tokens[$stackPtr - 1]['type'] === 'T_DOUBLE_COLON' && isset($tokens[$stackPtr - 2]['content'])) {
+			return $tokens[$stackPtr - 2]['content'];
+		}
+		return null;
+	}
+
+	public function isFunctionAMethod(File $phpcsFile, $stackPtr): bool {
+		$tokens = $phpcsFile->getTokens();
+		$currentToken = $tokens[$stackPtr];
+		return ! empty($currentToken['conditions']);
+	}
+
+	public function isSymbolADefinition(File $phpcsFile, Symbol $symbol): bool {
+		// if the previous non-whitespace token is const, function, class, or trait, it is a definition
+		// Note: this does not handle use statements, for that use isWithinUseStatement
+		$stackPtr = $symbol->getSymbolPosition();
+		$prevToken = $this->getPreviousNonWhitespaceToken($phpcsFile, $stackPtr) ?? [];
+		return $this->isTokenADefinition($prevToken) || $this->isWithinDefineCall($phpcsFile, $stackPtr) || $this->isWithinDeclareCall($phpcsFile, $stackPtr);
+	}
+
+	public function isTokenADefinition(array $token): bool {
+		// Note: this does not handle use or define
+		$type = $token['type'] ?? '';
+		$definitionTypes = ['T_CLASS', 'T_FUNCTION', 'T_CONST'];
+		return in_array($type, $definitionTypes, true);
+	}
+
+	public function getFullSymbol($phpcsFile, $stackPtr): Symbol {
+		$originalPtr = $stackPtr;
+		$tokens = $phpcsFile->getTokens();
+		// go backwards and forward and collect all the tokens until we encounter
+		// anything other than a backslash or a string
+		$currentToken = Symbol::getTokenWithPosition($tokens[$stackPtr], $stackPtr);
+		$fullSymbolParts = [];
+		while ($this->isTokenASymbolPart($currentToken)) {
+			$fullSymbolParts[] = $currentToken;
+			$stackPtr--;
+			$currentToken = Symbol::getTokenWithPosition($tokens[$stackPtr] ?? [], $stackPtr);
+		}
+		$fullSymbolParts = array_reverse($fullSymbolParts);
+		$stackPtr = $originalPtr + 1;
+		$currentToken = Symbol::getTokenWithPosition($tokens[$stackPtr] ?? [], $stackPtr);
+		while ($this->isTokenASymbolPart($currentToken)) {
+			$fullSymbolParts[] = $currentToken;
+			$stackPtr++;
+			$currentToken = Symbol::getTokenWithPosition($tokens[$stackPtr] ?? [], $stackPtr);
+		}
+		return new Symbol($fullSymbolParts);
+	}
+
+	public function isTokenASymbolPart(array $token): bool {
+		$type = $token['type'] ?? '';
+		$symbolParts = ['T_NS_SEPARATOR', 'T_STRING', 'T_RETURN_TYPE'];
+		return in_array($type, $symbolParts, true);
 	}
 }

--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -302,6 +302,10 @@ class SniffHelpers {
 	}
 
 	public function isWithinUseStatement(File $phpcsFile, $stackPtr): bool {
+		$isClosureImport = $phpcsFile->findNext([T_OPEN_PARENTHESIS], $stackPtr + 1, $stackPtr + 5);
+		if ($isClosureImport) {
+			return false;
+		}
 		$previousStatementPtr = $this->getPreviousStatementPtr($phpcsFile, $stackPtr);
 		return !! $phpcsFile->findPrevious([T_USE], $stackPtr - 1, $previousStatementPtr);
 	}

--- a/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
+++ b/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
@@ -2,17 +2,239 @@
 
 namespace NeutronStandard\Sniffs\Imports;
 
+use NeutronStandard\Symbol;
+use NeutronStandard\ImportedSymbol;
 use NeutronStandard\SniffHelpers;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
 class RequireImportsSniff implements Sniff {
+	public $ignoreUnimportedSymbols = null;
+
+	private $importedFunctions = [];
+	private $importedConsts = [];
+	private $importedClasses = [];
+	private $importedSymbolRecords = [];
+	private $seenSymbols = [];
+
 	public function register() {
-		return [];
+		return [T_USE, T_STRING, T_RETURN_TYPE, T_WHITESPACE];
 	}
 
 	public function process(File $phpcsFile, $stackPtr) {
-		$error = 'Function imports must be explicitly imported';
-		$phpcsFile->addError($error, $stackPtr, 'Function');
+		$helper = new SniffHelpers();
+		$tokens = $phpcsFile->getTokens();
+		$token = $tokens[$stackPtr];
+		if ($token['type'] === 'T_WHITESPACE') {
+			return $this->processEndOfFile($phpcsFile, $stackPtr);
+		}
+		if ($token['type'] === 'T_USE') {
+			return $this->processUse($phpcsFile, $stackPtr);
+		}
+		$symbol = $helper->getFullSymbol($phpcsFile, $stackPtr);
+		// If the symbol has been seen before (if this is a duplicate), ignore it
+		if (in_array($symbol, $this->seenSymbols)) {
+			return;
+		}
+		$this->seenSymbols[] = $symbol;
+		// If the symbol is in the ignore list, ignore it
+		if ($this->isSymbolIgnored($symbol)) {
+			return;
+		}
+		// If the symbol is a fully-qualified namespace, ignore it
+		if ($symbol->isAbsoluteNamespace()) {
+			return;
+		}
+		// If this symbol is a definition, ignore it
+		if ($helper->isSymbolADefinition($phpcsFile, $symbol)) {
+			return;
+		}
+		// If this symbol is a static reference or an object reference, ignore it
+		if ($helper->isStaticReference($phpcsFile, $stackPtr) || $helper->isObjectReference($phpcsFile, $stackPtr)) {
+			return;
+		}
+		// If this symbol is a namespace definition, ignore it
+		if ($helper->isWithinNamespaceStatement($phpcsFile, $symbol->getSymbolPosition())) {
+			return;
+		}
+		// If this symbol is an import, ignore it
+		if ($helper->isWithinUseStatement($phpcsFile, $symbol->getSymbolPosition())) {
+			return;
+		}
+		// If the symbol is predefined, ignore it
+		if ($helper->isPredefinedConstant($phpcsFile, $stackPtr) || $helper->isBuiltInFunction($phpcsFile, $stackPtr)) {
+			return;
+		}
+		// If this symbol is a predefined typehint, ignore it
+		if ($helper->isPredefinedTypehint($phpcsFile, $stackPtr)) {
+			return;
+		}
+		// If the symbol's namespace is imported or defined, ignore it
+		// If the symbol has no namespace and is itself is imported or defined, ignore it
+		if ($this->isSymbolDefined($phpcsFile, $symbol)) {
+			$this->markSymbolUsed($symbol);
+			return;
+		}
+		$error = "Found unimported symbol '{$symbol->getName()}'.";
+		$phpcsFile->addWarning($error, $stackPtr, 'Symbol');
+	}
+
+	private function isSymbolIgnored(Symbol $symbol): bool {
+		$symbolName = $symbol->getName();
+		$pattern = $this->getIgnoredSymbolPattern();
+		if (empty($pattern)) {
+			return false;
+		}
+		try {
+			return (1 === preg_match($pattern, $symbolName));
+		} catch (\Exception $err) {
+			throw new \Exception("ignoreUnimportedSymbols contains an invalid pattern: '{$pattern}'");
+		}
+	}
+
+	private function getIgnoredSymbolPattern() {
+		return $this->ignoreUnimportedSymbols ?? '';
+	}
+
+	private function isSymbolDefined(File $phpcsFile, Symbol $symbol): bool {
+		$namespace = $symbol->getTopLevelNamespace();
+		// If the symbol's namespace is imported or defined, ignore it
+		if ($namespace) {
+			return $this->isNamespaceImportedOrDefined($phpcsFile, $namespace);
+		}
+		// If the symbol has no namespace and is itself is imported or defined, ignore it
+		return $this->isNamespaceImportedOrDefined($phpcsFile, $symbol->getName());
+	}
+
+	private function isNamespaceImportedOrDefined(File $phpcsFile, string $namespace): bool {
+		return (
+			$this->isClassImported($namespace)
+			|| $this->isClassDefined($phpcsFile, $namespace)
+			|| $this->isFunctionImported($namespace)
+			|| $this->isFunctionDefined($phpcsFile, $namespace)
+			|| $this->isConstImported($namespace)
+			|| $this->isConstDefined($phpcsFile, $namespace)
+		);
+	}
+
+	private function processUse(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$importType = $helper->getImportType($phpcsFile, $stackPtr);
+		switch ($importType) {
+			case 'function':
+				return $this->saveFunctionImport($phpcsFile, $stackPtr);
+			case 'const':
+				return $this->saveConstImport($phpcsFile, $stackPtr);
+			case 'class':
+				return $this->saveClassImport($phpcsFile, $stackPtr);
+		}
+	}
+
+	private function recordImportedSymbols(int $stackPtr, array $importNames) {
+		foreach ($importNames as $symbol) {
+			$this->importedSymbolRecords[] = new ImportedSymbol($stackPtr, $symbol);
+		}
+	}
+
+	private function saveFunctionImport(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$importNames = $helper->getImportNames($phpcsFile, $stackPtr);
+		$this->recordImportedSymbols($stackPtr, $importNames);
+		$this->importedFunctions = array_merge($this->importedFunctions, $importNames);
+	}
+
+	private function saveConstImport(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$importNames = $helper->getImportNames($phpcsFile, $stackPtr);
+		$this->recordImportedSymbols($stackPtr, $importNames);
+		$this->importedConsts = array_merge($this->importedConsts, $importNames);
+	}
+
+	private function saveClassImport(File $phpcsFile, $stackPtr) {
+		$helper = new SniffHelpers();
+		$importNames = $helper->getImportNames($phpcsFile, $stackPtr);
+		$this->recordImportedSymbols($stackPtr, $importNames);
+		$this->importedClasses = array_merge($this->importedClasses, $importNames);
+	}
+
+	private function isFunctionImported(string $functionName): bool {
+		return in_array($functionName, $this->importedFunctions);
+	}
+
+	private function isConstImported(string $constName): bool {
+		return in_array($constName, $this->importedConsts);
+	}
+
+	private function isClassImported(string $name): bool {
+		return in_array($name, $this->importedClasses);
+	}
+
+	private function isClassDefined(File $phpcsFile, string $className): bool {
+		$classPtr = $phpcsFile->findNext([T_CLASS], 0);
+		while ($classPtr) {
+			$thisClassName = $phpcsFile->getDeclarationName($classPtr);
+			if ($className === $thisClassName) {
+				return true;
+			}
+			$classPtr = $phpcsFile->findNext([T_CLASS], $classPtr + 1);
+		}
+		return false;
+	}
+
+	private function isFunctionDefined(File $phpcsFile, string $functionName): bool {
+		$functionPtr = $phpcsFile->findNext([T_FUNCTION], 0);
+		while ($functionPtr) {
+			$thisFunctionName = $phpcsFile->getDeclarationName($functionPtr);
+			if ($functionName === $thisFunctionName) {
+				return true;
+			}
+			$functionPtr = $phpcsFile->findNext([T_FUNCTION], $functionPtr + 1);
+		}
+		return false;
+	}
+
+	private function isConstDefined(File $phpcsFile, string $functionName): bool {
+		$helper = new SniffHelpers();
+		$functionPtr = $phpcsFile->findNext([T_CONST], 0);
+		while ($functionPtr) {
+			$thisFunctionName = $helper->getConstantName($phpcsFile, $functionPtr);
+			if ($functionName === $thisFunctionName) {
+				return true;
+			}
+			$functionPtr = $phpcsFile->findNext([T_CONST], $functionPtr + 1);
+		}
+		return false;
+	}
+
+	private function markSymbolUsed(Symbol $symbol) {
+		$record = $this->getSymbolRecord($symbol);
+		if (! $record) {
+			return;
+		}
+		$record->markUsed();
+	}
+
+	private function getSymbolRecord(Symbol $symbol) {
+		foreach ($this->importedSymbolRecords as $record) {
+			if ($record->getName() === $symbol->getTopLevelNamespace()) {
+				return $record;
+			}
+		}
+		return null;
+	}
+
+	private function processEndOfFile(File $phpcsFile, int $stackPtr) {
+		$tokens = $phpcsFile->getTokens();
+		// If this is not the end of the file, ignore it
+		if (isset($tokens[$stackPtr + 1])) {
+			return;
+		}
+		// For each import, if the Symbol was not used, mark a warning
+		foreach ($this->importedSymbolRecords as $record) {
+			if (! $record->isUsed()) {
+				$error = "Found unused symbol '{$record->getName()}'.";
+				$phpcsFile->addWarning($error, $record->getPtr(), 'Import');
+			}
+		}
 	}
 }

--- a/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
+++ b/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
@@ -39,6 +39,7 @@ class RequireImportsSniff implements Sniff {
 		$this->seenSymbols[] = $symbol;
 		// If the symbol is in the ignore list, ignore it
 		if ($this->isSymbolIgnored($symbol)) {
+			$this->markSymbolUsed($symbol);
 			return;
 		}
 		// If the symbol is a fully-qualified namespace, ignore it

--- a/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
+++ b/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NeutronStandard\Sniffs\Imports;
+
+use NeutronStandard\SniffHelpers;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class RequireImportsSniff implements Sniff {
+	public function register() {
+		return [];
+	}
+
+	public function process(File $phpcsFile, $stackPtr) {
+		$error = 'Function imports must be explicitly imported';
+		$phpcsFile->addError($error, $stackPtr, 'Function');
+	}
+}

--- a/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
+++ b/NeutronStandard/Sniffs/Imports/RequireImportsSniff.php
@@ -183,10 +183,11 @@ class RequireImportsSniff implements Sniff {
 	}
 
 	private function isFunctionDefined(File $phpcsFile, string $functionName): bool {
+		$helper = new SniffHelpers();
 		$functionPtr = $phpcsFile->findNext([T_FUNCTION], 0);
 		while ($functionPtr) {
 			$thisFunctionName = $phpcsFile->getDeclarationName($functionPtr);
-			if ($functionName === $thisFunctionName) {
+			if ($functionName === $thisFunctionName && ! $helper->isFunctionAMethod($phpcsFile, $functionPtr)) {
 				return true;
 			}
 			$functionPtr = $phpcsFile->findNext([T_FUNCTION], $functionPtr + 1);

--- a/NeutronStandard/Symbol.php
+++ b/NeutronStandard/Symbol.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandard;
+
+class Symbol {
+	private $tokens;
+
+	public function __construct(array $tokens) {
+		if (empty($tokens)) {
+			throw new \Exception('Symbols cannot be empty');
+		}
+		$this->tokens = $tokens;
+	}
+
+	public static function getTokenWithPosition(array $token, int $stackPtr): array {
+		$token['tokenPosition'] = $stackPtr;
+		return $token;
+	}
+
+	public function getTokens(): array {
+		return $this->tokens;
+	}
+
+	public function getName(): string {
+		return $this->joinSymbolParts($this->tokens);
+	}
+
+	public function isAbsoluteNamespace(): bool {
+		$type = $this->tokens[0]['type'] ?? '';
+		return $type === 'T_NS_SEPARATOR';
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getTopLevelNamespace() {
+		return $this->tokens[0]['content'] ?? null;
+	}
+
+	public function getSymbolPosition(): int {
+		return $this->tokens[0]['tokenPosition'] ?? 1;
+	}
+
+	private function joinSymbolParts(array $tokens): string {
+		$symbolStrings = array_map(function (array $token): string {
+			return $token['content'] ?? '';
+		}, $tokens);
+		return implode('', $symbolStrings);
+	}
+}

--- a/tests/SniffTestHelper.php
+++ b/tests/SniffTestHelper.php
@@ -23,7 +23,9 @@ class SniffTestHelper {
 	}
 
 	public function getLineNumbersFromMessages(array $messages): array {
-		return array_keys($messages);
+		$lines = array_keys($messages);
+		sort($lines);
+		return $lines;
 	}
 
 	public function getWarningLineNumbersFromFile(LocalFile $phpcsFile): array {

--- a/tests/Sniffs/Imports/RequireImportsAllowedPatternFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsAllowedPatternFixture.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace CAR_APP\Vehicles\Greatness;
+
+use function whitelisted_function;
+
+class GreatClass {
+	private function activate() {
+		whitelisted_function();
+	}
+}

--- a/tests/Sniffs/Imports/RequireImportsAllowedPatternFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsAllowedPatternFixture.php
@@ -8,5 +8,7 @@ use function whitelisted_function;
 class GreatClass {
 	private function activate() {
 		whitelisted_function();
+		another_whitelisted_function();
+		non_whitelisted_function(); // this should report an unimported function
 	}
 }

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -95,9 +95,11 @@ function startMonitor() {
 	OldAlerts\makeAlert();
 	new Car();
 	echo str_replace('Foo', 'Bar', 'Foobar...');
-	monitor_begin();
-	whitelisted_function();
-	allowed_funcs_function_one();
+	$rows = whitelisted_function();
+	$data = allowed_funcs_function_one();
+	array_map(function (array $row) use ($data) {
+		$data && monitor_begin($row);
+	}, $rows);
 }
 
 define(WHATEVER, 'some words');

--- a/tests/Sniffs/Imports/RequireImportsFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsFixture.php
@@ -1,0 +1,103 @@
+<?php
+declare( strict_types=1 );
+
+namespace CAR_APP\Vehicles;
+
+use Physics\MovementType;
+use VehicleWithEmissions as PollutionProducer;
+use function Roads\getSpeedLimit;
+use function monitor_begin;
+use function Physics\{ // this line has an unused import
+	setMoving,
+	setMovable as makeItMove,
+	setStopped
+};
+use CAR_APP_GLOBALS; // this line has an unused import
+use WeatherStore;
+use WeatherModels\Storm;
+use const Weather\SNOW;
+use const Weather\{RAIN, SLEET, CAR_IN_WEATHER}; // this line has an unused import
+use Notifications\Alerts;
+
+const TYPE = 'Car';
+
+class Car {
+	public function drive(string $whereTo, Car $previousCar = null): void {
+		// next line has unimported function
+		$currentWeather = getWeather();
+		if ($currentWeather === SNOW) {
+			// next line has unimported class
+			return new DrivingProblem('weather is too harsh');
+		}
+		if ($currentWeather === RAIN) {
+			// next line has unimported class
+			return new DrivingProblem('weather is too harsh');
+		}
+		// next line has unimported const
+		if ($currentWeather === SUN) {
+			// next line has unimported class
+			if (DataStore::readyToMark()) {
+				WeatherStore::markGoodDay();
+			}
+		}
+		if ($currentWeather instanceof Storm) {
+			return new \Exception('stormy');
+		}
+		// next line has unimported class
+		if ($currentWeather instanceof Drizzle) {
+			throw new \Exception();
+		}
+		if (getSpeedLimit() < 1) {
+			// next line has unimported class
+			return new DrivingProblem('no speed limit');
+		}
+		setMoving(TYPE, true);
+		\Physics\setMoving(TYPE, 'drive');
+		// next line has an unimported function
+		setMovable(CAR_IN_WEATHER);
+		makeItMove(CAR_IN_WEATHER);
+		startMonitor();
+		$this->polluter = new PollutionProducer();
+		// next line has an unimported class
+		$data = new stdClass(PHP_VERSION);
+		$store = new WeatherStore($data);
+		try {
+			$store->trackWeather($store->key);
+		} catch (\MyException $err) {
+			Alerts\makeAnAlert($err);
+			// next line has an unimported function
+			OldAlerts\makeAlert($err);
+			// next line has an unimported class
+			$oldAlert = new OldAlerts\OldAlert();
+			// next line has an unimported class
+			$oldAlert = OldAlerts\OldAlert::makeRed($oldAlert);
+			$oldAlert->warn();
+			$alert = new Alerts\MyAlert();
+			$alert = Alerts\MyAlert::markAlertImportant($alert);
+			$alert->notifyUser();
+			// next line has an unimported class
+			return new Exception('buggy');
+		}
+		$name = $store->current_name_as_string;
+		$data = new \stdClass(PHP_VERSION);
+		return new MovementType('driving in ' . $name);
+	}
+
+	// next line has an unimported class
+	public function convertToRobot(Car $car): Robot {
+		// next line has an unimported class
+		return new Robot($car);
+	}
+}
+
+function startMonitor() {
+	// next line has an unimported function
+	OldAlerts\makeAlert();
+	new Car();
+	echo str_replace('Foo', 'Bar', 'Foobar...');
+	monitor_begin();
+	whitelisted_function();
+	allowed_funcs_function_one();
+}
+
+define(WHATEVER, 'some words');

--- a/tests/Sniffs/Imports/RequireImportsMethodNameFixture.php
+++ b/tests/Sniffs/Imports/RequireImportsMethodNameFixture.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace CAR_APP\Vehicles\Greatness;
+
+class GreatClass {
+	private function activate() {
+	}
+
+	public function run() {
+		activate(); // should report unimported function
+	}
+}

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -43,6 +43,25 @@ class RequireImportsSniffTest extends TestCase {
 		$this->assertSame(count($expectedLines), $phpcsFile->getWarningCount());
 	}
 
+	public function testRequireImportsSniffFindsUnimportedFunctionsWithNoConfig() {
+		$fixtureFile = __DIR__ . '/RequireImportsAllowedPatternFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->ruleset->setSniffProperty(
+			'NeutronStandard\Sniffs\Imports\RequireImportsSniff',
+			'ignoreUnimportedSymbols',
+			''
+		);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [
+			11,
+			12,
+		];
+		$this->assertEquals($expectedLines, $lines);
+	}
+
 	public function testRequireImportsSniffIgnoresAllowedImports() {
 		$fixtureFile = __DIR__ . '/RequireImportsAllowedPatternFixture.php';
 		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Imports/RequireImportsSniff.php';
@@ -51,11 +70,11 @@ class RequireImportsSniffTest extends TestCase {
 		$phpcsFile->ruleset->setSniffProperty(
 			'NeutronStandard\Sniffs\Imports\RequireImportsSniff',
 			'ignoreUnimportedSymbols',
-			'/^(something_to_ignore|whitelisted_function|allowed_funcs_\w+)$/'
+			'/^(something_to_ignore|whitelisted_function|allowed_funcs_\w+|another_[a-z_]+)$/'
 		);
 		$phpcsFile->process();
 		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
-		$expectedLines = [];
+		$expectedLines = [ 12 ];
 		$this->assertEquals($expectedLines, $lines);
 	}
 

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -42,4 +42,20 @@ class RequireImportsSniffTest extends TestCase {
 		$this->assertEquals($expectedLines, $lines);
 		$this->assertSame(count($expectedLines), $phpcsFile->getWarningCount());
 	}
+
+	public function testRequireImportsSniffIgnoresAllowedImports() {
+		$fixtureFile = __DIR__ . '/RequireImportsAllowedPatternFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->ruleset->setSniffProperty(
+			'NeutronStandard\Sniffs\Imports\RequireImportsSniff',
+			'ignoreUnimportedSymbols',
+			'/^(something_to_ignore|whitelisted_function|allowed_funcs_\w+)$/'
+		);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [];
+		$this->assertEquals($expectedLines, $lines);
+	}
 }

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace NeutronStandardTest;
+
+use PHPUnit\Framework\TestCase;
+
+class RequireImportsSniffTest extends TestCase {
+	public function testRequireImportsSniff() {
+		$fixtureFile = __DIR__ . '/RequireImportsFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->ruleset->setSniffProperty(
+			'NeutronStandard\Sniffs\Imports\RequireImportsSniff',
+			'ignoreUnimportedSymbols',
+			'/^(something_to_ignore|whitelisted_function|allowed_funcs_\w+)$/'
+		);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [
+			10,
+			15,
+			19,
+			27,
+			30,
+			34,
+			37,
+			39,
+			47,
+			52,
+			57,
+			62,
+			69,
+			71,
+			73,
+			79,
+			87,
+			89,
+			95,
+		];
+		$this->assertEquals($expectedLines, $lines);
+		$this->assertSame(count($expectedLines), $phpcsFile->getWarningCount());
+	}
+}

--- a/tests/Sniffs/Imports/RequireImportsSniffTest.php
+++ b/tests/Sniffs/Imports/RequireImportsSniffTest.php
@@ -58,4 +58,15 @@ class RequireImportsSniffTest extends TestCase {
 		$expectedLines = [];
 		$this->assertEquals($expectedLines, $lines);
 	}
+
+	public function testRequireImportsSniffDoesNotCountMethodNames() {
+		$fixtureFile = __DIR__ . '/RequireImportsMethodNameFixture.php';
+		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Imports/RequireImportsSniff.php';
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [ 11 ];
+		$this->assertEquals($expectedLines, $lines);
+	}
 }


### PR DESCRIPTION
This adds a sniff which shows warnings if a symbol (function, constant, class) is used and is not defined directly, imported explicitly, nor has its namespace imported.

When code is moved around, it can be problematic if classes which are used in a relative or global context get moved to a different namespace. In those cases it's better if the classes use their fully-qualified namespace, or if they are imported explicitly using `use` (in which case they can be detected by a linter like this one). These warnings should help when refactoring code to avoid bugs.

It also detects imports which are _not_ being used.

For example:

```php
namespace Vehicles;
use Registry;
use function Vehicles\startCar;
use Chocolate; // this will be a warning because `Chocolate` is never used
class Car {
  public function drive() {
    startCar(); // this is fine because `startCar` is imported
    Registry\registerCar($this); // this is fine because `Registry` is imported
    goFaster(); // this will be a warning because `goFaster` was not imported
  }
}
```

You can use the config option `ignoreUnimportedSymbols` to ignore as many symbols as you like. It is a regular expression. Here's an example:

```xml
	<rule ref="NeutronStandard.Imports.RequireImports">
		<properties>
			<property name="ignoreUnimportedSymbols" value="/^(wp_parse_args|OBJECT\S*|ARRAY_\S+|is_wp_error|__|esc_html__|get_blog_\S+)$/"/>
		</properties>
	</rule>
```

This is a revised version of #57.

Fixes #45 in a way which is less risky than #57 by allowing absolute imports and namespace imports.

Things still to do:
- [x] Make compatible with PHP 7.0 (remove all those nullable return types)
- [x] Add support for a config option that adds new symbol names to ignore (eg: all the WP ones)
- [ ] Add docs for the new option
- [x] Clean up all these commits