### PR TITLE
Lock phpcs at 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "phpunit/phpunit": "^6.4",
         "limedeck/phpunit-detailed-printer": "^3.1",
-        "squizlabs/php_codesniffer": "^3.2.1"
+        "squizlabs/php_codesniffer": "3.2.3"
     }
 }


### PR DESCRIPTION
PHPCS 3.3 contains several breaking changes. See #62