### PR TITLE
composer: add PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
     "scripts": {
         "test": "./vendor/bin/phpunit"
     },
-    "require": {},
+    "require": {
+        "php": "^7.0"
+    },
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",


### PR DESCRIPTION
This prevents errors on lower PHP versions.

Not sure if the version correct. I guess it based on travis.yml :)