### PR TITLE
Add maxFunctionLines as option on LongFunctionSniff

### DIFF
--- a/NeutronStandard/Sniffs/Functions/LongFunctionSniff.php
+++ b/NeutronStandard/Sniffs/Functions/LongFunctionSniff.php
@@ -7,6 +7,8 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Files\File;
 
 class LongFunctionSniff implements Sniff {
+	public $maxFunctionLines = 40;
+
 	public function register() {
 		return [T_FUNCTION];
 	}
@@ -49,10 +51,8 @@ class LongFunctionSniff implements Sniff {
 				$foundNonComment = false;
 			}
 		}
-		// $functionName = $phpcsFile->getDeclarationName($stackPtr);
-		// echo "\nFunction $functionName is $newlineCount lines long.\n";
-		if ($newlineCount > 20) {
-			$error = 'Function is longer than 20 lines';
+		if (intval($newlineCount) > $this->maxFunctionLines) {
+			$error = "Function is longer than {$this->maxFunctionLines} lines";
 			$phpcsFile->addWarning($error, $stackPtr, 'LongFunction');
 		}
 	}

--- a/NeutronStandard/Sniffs/Functions/LongFunctionSniff.php
+++ b/NeutronStandard/Sniffs/Functions/LongFunctionSniff.php
@@ -19,7 +19,10 @@ class LongFunctionSniff implements Sniff {
 			return;
 		}
 		$tokens = $phpcsFile->getTokens();
-		$startOfFunctionPtr = $helper->getStartOfFunctionPtr($phpcsFile, $stackPtr);
+		$startOfFunctionPtr = $helper->getStartOfFunctionPtr(
+			$phpcsFile,
+			$stackPtr
+		);
 		$endOfFunctionPtr = $helper->getEndOfFunctionPtr($phpcsFile, $stackPtr);
 		$newlineCount = 0;
 		$commentTokens = [
@@ -28,25 +31,34 @@ class LongFunctionSniff implements Sniff {
 			T_DOC_COMMENT_STRING,
 			T_COMMENT,
 			T_DOC_COMMENT_STAR,
-			T_DOC_COMMENT_WHITESPACE
+			T_DOC_COMMENT_WHITESPACE,
 		];
-		$newlineContainingTokens = [
-			T_WHITESPACE,
-			T_COMMENT,
-		];
-		$currentLinePtr = $phpcsFile->findNext(T_WHITESPACE, $startOfFunctionPtr, $endOfFunctionPtr, false, "\n") + 2;
+		$newlineContainingTokens = [T_WHITESPACE, T_COMMENT];
+		$currentLinePtr =
+			$phpcsFile->findNext(
+				T_WHITESPACE,
+				$startOfFunctionPtr,
+				$endOfFunctionPtr,
+				false,
+				"\n"
+			) + 2;
 		$foundNonComment = false;
 		for ($index = $currentLinePtr; $index < $endOfFunctionPtr; $index++) {
 			$token = $tokens[$index];
-			if (! in_array($token['code'], $commentTokens)) {
-				if ($token['code'] !== T_WHITESPACE || $token['content'] !== "\n") {
+			if (!in_array($token['code'], $commentTokens)) {
+				if (
+					$token['code'] !== T_WHITESPACE ||
+					$token['content'] !== "\n"
+				) {
 					$foundNonComment = true;
 				}
 			}
-			if (in_array($token['code'], $newlineContainingTokens) &&
-				$helper->doesStringEndWith($token['content'], "\n")) {
+			if (
+				in_array($token['code'], $newlineContainingTokens) &&
+				$helper->doesStringEndWith($token['content'], "\n")
+			) {
 				if ($foundNonComment) {
-					$newlineCount ++;
+					$newlineCount++;
 				}
 				$foundNonComment = false;
 			}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,24 +1,17 @@
 <?xml version="1.0"?>
 <ruleset name="MyStandard">
     <description>
-        From https://gist.github.com/Ovsyanka/e2ab2ff76e7c0d7e75a1e4213a03ff95
-        PSR2 with changes:
-            * tabs instead of spaces (https://gist.github.com/gsherwood/9d22f634c57f990a7c64)
-            * bracers on end of line instead new line
+        My standard for this project
     </description>
 
-    <!-- tabs -->
     <arg name="tab-width" value="4"/>
     <rule ref="PSR2">
-        <!-- bracers -->
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine" />
         <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine" />
-
-        <!-- tabs -->
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace" />
         <exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
     </rule>
 
-    <!-- tabs -->
     <rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
     <rule ref="Generic.WhiteSpace.ScopeIndent">
         <properties>
@@ -27,11 +20,9 @@
         </properties>
     </rule>
 
-    <!-- bracers -->
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
     <rule ref="Generic.Classes.OpeningBraceSameLine"/>
 
-    <!-- variables: https://github.com/sirbrillig/VariableAnalysis/ -->
     <rule ref="VariableAnalysis"/>
     <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
         <type>error</type>

--- a/tests/Sniffs/Functions/LongFunctionSniffTest.php
+++ b/tests/Sniffs/Functions/LongFunctionSniffTest.php
@@ -7,13 +7,18 @@ use PHPUnit\Framework\TestCase;
 
 class LongFunctionSniffTest extends TestCase {
 	public function testLongFunctionSniff() {
-		$fixtureFile = __DIR__ . '/FunctionsFixture.php';
-		$sniffFile = __DIR__ . '/../../../NeutronStandard/Sniffs/Functions/LongFunctionSniff.php';
+		$fixtureFile = __DIR__ . '/LongFunctionsFixture.php';
+		$sniffFile =
+			__DIR__ .
+			'/../../../NeutronStandard/Sniffs/Functions/LongFunctionSniff.php';
 
 		$helper = new SniffTestHelper();
-		$phpcsFile = $helper->prepareLocalFileForSniffs($sniffFile, $fixtureFile);
+		$phpcsFile = $helper->prepareLocalFileForSniffs(
+			$sniffFile,
+			$fixtureFile
+		);
 		$phpcsFile->process();
-		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
-		$this->assertEquals([37, 72], $lines);
+		$warnings = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$this->assertEquals([61], $warnings);
 	}
 }

--- a/tests/Sniffs/Functions/LongFunctionSniffTest.php
+++ b/tests/Sniffs/Functions/LongFunctionSniffTest.php
@@ -21,4 +21,48 @@ class LongFunctionSniffTest extends TestCase {
 		$warnings = $helper->getWarningLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([61], $warnings);
 	}
+
+	public function testLongFunctionWithDifferentLength() {
+		$fixtureFile = __DIR__ . '/LongFunctionsFixture.php';
+		$sniffFile =
+			__DIR__ .
+			'/../../../NeutronStandard/Sniffs/Functions/LongFunctionSniff.php';
+
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs(
+			$sniffFile,
+			$fixtureFile
+		);
+		$phpcsFile->ruleset->setSniffProperty(
+			'NeutronStandard\Sniffs\Functions\LongFunctionSniff',
+			'maxFunctionLines',
+			'50'
+		);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [];
+		$this->assertEquals($expectedLines, $lines);
+	}
+
+	public function testLongFunctionWithShorterLength() {
+		$fixtureFile = __DIR__ . '/LongFunctionsFixture.php';
+		$sniffFile =
+			__DIR__ .
+			'/../../../NeutronStandard/Sniffs/Functions/LongFunctionSniff.php';
+
+		$helper = new SniffTestHelper();
+		$phpcsFile = $helper->prepareLocalFileForSniffs(
+			$sniffFile,
+			$fixtureFile
+		);
+		$phpcsFile->ruleset->setSniffProperty(
+			'NeutronStandard\Sniffs\Functions\LongFunctionSniff',
+			'maxFunctionLines',
+			'2'
+		);
+		$phpcsFile->process();
+		$lines = $helper->getWarningLineNumbersFromFile($phpcsFile);
+		$expectedLines = [3, 61];
+		$this->assertEquals($expectedLines, $lines);
+	}
 }

--- a/tests/Sniffs/Functions/LongFunctionsFixture.php
+++ b/tests/Sniffs/Functions/LongFunctionsFixture.php
@@ -1,0 +1,106 @@
+<?php
+abstract class MyClass {
+	public function notTooLong() {
+		/**
+		 * Lorem ipsum
+		 * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ullamcorper
+		 * turpis vel lacus tincidunt accumsan. Pellentesque varius tristique tortor, non
+		 * tincidunt elit porta ac. Praesent eget interdum turpis. Donec sodales ultrices
+		 * metus at cursus. Phasellus vehicula augue eu elit semper mollis vitae aliquam
+		 * lacus. Proin a egestas dui. Nam aliquet ultricies ipsum, eget bibendum lacus.
+		 * Donec ut neque ultricies, mattis urna non, ullamcorper risus. Mauris efficitur
+		 * tortor justo, a commodo justo tempus non. Nullam commodo vehicula magna ac
+		 * malesuada. Nulla suscipit vulputate feugiat. Donec quis dignissim mauris.
+		 * Integer volutpat mi ut urna molestie, sit amet placerat felis vestibulum.
+		 * Quisque vulputate, metus et viverra condimentum, lacus purus ultricies odio,
+		 * non placerat justo erat vitae nulla. Duis viverra mauris mi, ac hendrerit metus
+		 * dapibus iaculis.
+		 * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ullamcorper
+		 * turpis vel lacus tincidunt accumsan. Pellentesque varius tristique tortor, non
+		 * tincidunt elit porta ac. Praesent eget interdum turpis. Donec sodales ultrices
+		 * metus at cursus. Phasellus vehicula augue eu elit semper mollis vitae aliquam
+		 * lacus. Proin a egestas dui. Nam aliquet ultricies ipsum, eget bibendum lacus.
+		 * Donec ut neque ultricies, mattis urna non, ullamcorper risus. Mauris efficitur
+		 * tortor justo, a commodo justo tempus non. Nullam commodo vehicula magna ac
+		 * malesuada. Nulla suscipit vulputate feugiat. Donec quis dignissim mauris.
+		 * Integer volutpat mi ut urna molestie, sit amet placerat felis vestibulum.
+		 * Quisque vulputate, metus et viverra condimentum, lacus purus ultricies odio,
+		 * non placerat justo erat vitae nulla. Duis viverra mauris mi, ac hendrerit metus
+		 * dapibus iaculis.
+		 * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ullamcorper
+		 * turpis vel lacus tincidunt accumsan. Pellentesque varius tristique tortor, non
+		 * tincidunt elit porta ac. Praesent eget interdum turpis. Donec sodales ultrices
+		 * metus at cursus. Phasellus vehicula augue eu elit semper mollis vitae aliquam
+		 * lacus. Proin a egestas dui. Nam aliquet ultricies ipsum, eget bibendum lacus.
+		 * Donec ut neque ultricies, mattis urna non, ullamcorper risus. Mauris efficitur
+		 * tortor justo, a commodo justo tempus non. Nullam commodo vehicula magna ac
+		 * malesuada. Nulla suscipit vulputate feugiat. Donec quis dignissim mauris.
+		 * Integer volutpat mi ut urna molestie, sit amet placerat felis vestibulum.
+		 * Quisque vulputate, metus et viverra condimentum, lacus purus ultricies odio,
+		 * non placerat justo erat vitae nulla. Duis viverra mauris mi, ac hendrerit metus
+		 * dapibus iaculis.
+		 * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ullamcorper
+		 * turpis vel lacus tincidunt accumsan. Pellentesque varius tristique tortor, non
+		 * tincidunt elit porta ac. Praesent eget interdum turpis. Donec sodales ultrices
+		 * metus at cursus. Phasellus vehicula augue eu elit semper mollis vitae aliquam
+		 * lacus. Proin a egestas dui. Nam aliquet ultricies ipsum, eget bibendum lacus.
+		 * Donec ut neque ultricies, mattis urna non, ullamcorper risus. Mauris efficitur
+		 * tortor justo, a commodo justo tempus non. Nullam commodo vehicula magna ac
+		 * malesuada. Nulla suscipit vulputate feugiat. Donec quis dignissim mauris.
+		 * Integer volutpat mi ut urna molestie, sit amet placerat felis vestibulum.
+		 * Quisque vulputate, metus et viverra condimentum, lacus purus ultricies odio,
+		 * non placerat justo erat vitae nulla. Duis viverra mauris mi, ac hendrerit metus
+		 * dapibus iaculis.
+		 **/
+		$foo = 'bar';
+		$foo;
+		$foo; // Hello
+	}
+
+	// Next line should report function too long
+	public function tooLongWithComments() {
+		$foo = 'bar';
+		$foo;
+		$foo;
+		$foo;
+		$foo;
+		$foo;
+		$foo;
+		$foo;
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo;
+		$foo;
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo;
+		$foo;
+		$foo;
+		$foo;
+		$foo;
+		$foo;
+		$foo;
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo;
+		$foo;
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+		$foo; // Hello
+	}
+}


### PR DESCRIPTION
This adds the `maxFunctionLines` property on `LongFunctionSniff` so we can configure how many lines are too long. It also updates the sniff such that the default number of lines is 40, which matches the guidelines.