### PR TITLE
Fix unused return type for generators

### DIFF
--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -55,7 +55,7 @@ class SniffHelpers {
 
 	public function isReturnValueVoid(File $phpcsFile, $stackPtr) {
 		$tokens = $phpcsFile->getTokens();
-		if ($tokens[$stackPtr]['code'] !== T_RETURN) {
+		if (! in_array( $tokens[$stackPtr]['code'], [T_RETURN, T_YIELD], false)) {
 			return false;
 		}
 		$returnValue = $this->getNextNonWhitespace($phpcsFile, $stackPtr);

--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -68,7 +68,11 @@ class SniffHelpers {
 		if (! $colonPtr) {
 			return false;
 		}
-		return $phpcsFile->findNext([T_WHITESPACE,T_NULLABLE], $colonPtr + 1, null, true, null, true);
+		$endOfTypePtr = $phpcsFile->findNext([T_OPEN_CURLY_BRACKET, T_SEMICOLON], $colonPtr + 1);
+		if (! $endOfTypePtr) {
+			throw new \Exception('Found colon for return type but no end-of-line');
+		}
+		return $phpcsFile->findPrevious([T_WHITESPACE], $endOfTypePtr - 1, $colonPtr, true);
 	}
 
 	public function getNextSemicolonPtr(File $phpcsFile, $stackPtr) {

--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -55,7 +55,7 @@ class SniffHelpers {
 
 	public function isReturnValueVoid(File $phpcsFile, $stackPtr) {
 		$tokens = $phpcsFile->getTokens();
-		if (! in_array( $tokens[$stackPtr]['code'], [T_RETURN, T_YIELD], false)) {
+		if (! in_array($tokens[$stackPtr]['code'], [T_RETURN, T_YIELD], false)) {
 			return false;
 		}
 		$returnValue = $this->getNextNonWhitespace($phpcsFile, $stackPtr);

--- a/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
+++ b/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
@@ -81,7 +81,7 @@ class TypeHintSniff implements Sniff {
 			if ($token['code'] === T_CLOSURE) {
 				array_unshift($scopeClosers, $token['scope_closer']);
 			}
-			if (empty($scopeClosers) && in_array( $token['code'], [T_RETURN, T_YIELD], true)) {
+			if (empty($scopeClosers) && in_array($token['code'], [T_RETURN, T_YIELD], true)) {
 				$helper->isReturnValueVoid($phpcsFile, $ptr) ? $voidReturnCount++ : $nonVoidReturnCount++;
 			}
 		}

--- a/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
+++ b/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
@@ -81,7 +81,7 @@ class TypeHintSniff implements Sniff {
 			if ($token['code'] === T_CLOSURE) {
 				array_unshift($scopeClosers, $token['scope_closer']);
 			}
-			if (empty($scopeClosers) && $token['code'] === T_RETURN) {
+			if (empty($scopeClosers) && in_array( $token['code'], [T_RETURN, T_YIELD], true)) {
 				$helper->isReturnValueVoid($phpcsFile, $ptr) ? $voidReturnCount++ : $nonVoidReturnCount++;
 			}
 		}

--- a/tests/Sniffs/Functions/FunctionsFixture.php
+++ b/tests/Sniffs/Functions/FunctionsFixture.php
@@ -212,4 +212,11 @@ abstract class MyClass {
 		}
 		return 5;
 	}
+
+	// Test yield as a vaild return token
+	public function iteratorYield( \Iterator $iterator ): \Iterator {
+		foreach( $iterator as $i ) {
+			yield $i;
+		}
+	}
 }


### PR DESCRIPTION
`yield` is a valid keyword that acts as a return for generator functions.

Fixes #71 