### PR TITLE
Update dev dependencies to latest versions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop for this repo using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.travis.yml export-ignore
+/tests/ export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text
+*.inc text

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: 7.2
-    - php: nightly
-  allow_failures:
-    - php: nightly
+    - php: 7.3
+    - php: 7.4
   fast_finish: true
 
 os:

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,6 @@
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
         "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
-        "sirbrillig/phpcs-import-detection": "^1.1",
-        "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
-        "phpstan/phpstan": "^0.11.8"
+        "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     },
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-        "phpunit/phpunit": "^6.4",
-        "limedeck/phpunit-detailed-printer": "^3.1",
-        "squizlabs/php_codesniffer": "3.3.0"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+        "phpunit/phpunit": "^8",
+        "limedeck/phpunit-detailed-printer": "^5",
+        "squizlabs/php_codesniffer": "^3.5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,15 @@
         }
     },
     "require": {
-        "php": "^7.0"
+        "php": "^7.0",
+        "squizlabs/php_codesniffer": "^3.1"
     },
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
-        "phpunit/phpunit": "^8",
-        "limedeck/phpunit-detailed-printer": "^5",
-        "squizlabs/php_codesniffer": "^3.5.0"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
+        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
+        "sirbrillig/phpcs-import-detection": "^1.1",
+        "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
+        "phpstan/phpstan": "^0.11.8"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "test": "./vendor/bin/phpunit",
+        "test": "./vendor/bin/phpunit --testdox",
         "lint": "./vendor/bin/phpcs NeutronStandard"
     },
     "support"    : {
@@ -40,7 +40,6 @@
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
-        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
-        "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0"
+        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,22 @@
         "test": "./vendor/bin/phpunit",
         "lint": "./vendor/bin/phpcs NeutronStandard"
     },
+    "support"    : {
+        "issues": "https://github.com/sirbrillig/phpcs-neutron-standard/issues",
+        "wiki"  : "https://github.com/sirbrillig/phpcs-neutron-standard/wiki",
+        "source": "https://github.com/sirbrillig/phpcs-neutron-standard"
+    },
+    "config": {
+        "sort-order": true
+    },
     "autoload": {
         "psr-4": {
             "NeutronStandard\\": "NeutronStandard/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "NeutronStandard\\Tests\\": "tests/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "php": "^7.0",
-        "squizlabs/php_codesniffer": "^3.1"
+        "squizlabs/php_codesniffer": "^3.3.0"
     },
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 	printerClass="LimeDeck\Testing\Printer"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="NeutronStandard">
 			<directory>tests</directory>
 		</testsuite>
 	</testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <phpunit
 	bootstrap="tests/bootstrap.php"
-	printerClass="LimeDeck\Testing\Printer"
 	>
 	<testsuites>
 		<testsuite name="NeutronStandard">


### PR DESCRIPTION
Currently, when running `$ ./vendor/bin/phpunit` after a clean `composer install`, the following errors are reported.

```
1) NeutronStandardTest\DisallowLongformArraySniffTest::testDisallowLongformArraySniff
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Tokenizers/Tokenizer.php:746
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:167
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:167
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:134
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Tokenizers/PHP.php:14
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:167
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:134
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Sniffs/AbstractPatternSniff.php:917
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Sniffs/AbstractPatternSniff.php:825
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Sniffs/AbstractPatternSniff.php:90
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Ruleset.php:1197
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Ruleset.php:218
/dev/phpcs-neutron-standard/tests/SniffTestHelper.php:13
/dev/phpcs-neutron-standard/tests/Sniffs/Arrays/DisallowLongformArraySniffTest.php:14

2) NeutronStandardTest\DisallowLongformArraySniffTest::testFixDisallowLongFormArraySniff
"continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Files/File.php:1404
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:167
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:167
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:134
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/src/Files/LocalFile.php:16
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:167
/dev/phpcs-neutron-standard/vendor/squizlabs/php_codesniffer/autoload.php:134
/dev/phpcs-neutron-standard/tests/SniffTestHelper.php:22
/dev/phpcs-neutron-standard/tests/Sniffs/Arrays/DisallowLongformArraySniffTest.php:26
```

These errors are from phpcs. Updating all of our dev deps to their latest versions fixes this error, and the tests will pass with no errors.

**Testing:**
- Run `composer update`
- Run `/vendor/bin/phpunit`

