### PR TITLE
Add linting to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
 script:
   - composer install
   - composer test
+  - composer lint
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "test": "./vendor/bin/phpunit"
+        "test": "./vendor/bin/phpunit",
+        "lint": "./vendor/bin/phpcs NeutronStandard"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds a new `composer lint` script which will automatically run phpcs on the source files in the repo. It then adds that command to the Travis config so that it should be run on every PR.