### PR TITLE
Check for proper whitespaces for function return types

### DIFF
--- a/NeutronStandard/SniffHelpers.php
+++ b/NeutronStandard/SniffHelpers.php
@@ -68,7 +68,7 @@ class SniffHelpers {
 		if (! $colonPtr) {
 			return false;
 		}
-		return $phpcsFile->findNext(T_WHITESPACE, $colonPtr + 1, null, true, null, true);
+		return $phpcsFile->findNext([T_WHITESPACE,T_NULLABLE], $colonPtr + 1, null, true, null, true);
 	}
 
 	public function getNextSemicolonPtr(File $phpcsFile, $stackPtr) {

--- a/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
+++ b/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
@@ -59,7 +59,10 @@ class TypeHintSniff implements Sniff {
 				$phpcsFile->addError( 'Return type colon should be right after closing function parenthesis', $colonPtr, 'ExtraSpace' );
 			}
 			if ($tokens[$colonPtr + 1]['type'] !== 'T_WHITESPACE') {
-				$phpcsFile->addError( 'No space after return type', $colonPtr, 'MissingSpace' );
+				$phpcsFile->addError( 'Missing space before return type', $colonPtr, 'MissingSpace' );
+			}
+			if ($tokens[$returnTypePtr+1]['type'] !== 'T_WHITESPACE') {
+				$phpcsFile->addError( 'Missing space after return type', $colonPtr, 'MissingSpace' );
 			}
 		}
 

--- a/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
+++ b/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
@@ -56,13 +56,13 @@ class TypeHintSniff implements Sniff {
 		$colonPtr = $phpcsFile->findNext(T_COLON, $stackPtr, $startOfFunctionPtr);
 		if ($colonPtr) {
 			if ($tokens[$colonPtr - 1]['type'] !== 'T_CLOSE_PARENTHESIS') {
-				$phpcsFile->addError( 'Return type colon should be right after closing function parenthesis', $colonPtr, 'ExtraSpace' );
+				$phpcsFile->addError('Return type colon should be right after closing function parenthesis', $colonPtr, 'ExtraSpace');
 			}
 			if ($tokens[$colonPtr + 1]['type'] !== 'T_WHITESPACE') {
-				$phpcsFile->addError( 'Missing space before return type', $colonPtr, 'MissingSpace' );
+				$phpcsFile->addError('Missing space before return type', $colonPtr, 'MissingSpace');
 			}
 			if ($tokens[$returnTypePtr+1]['type'] !== 'T_WHITESPACE') {
-				$phpcsFile->addError( 'Missing space after return type', $colonPtr, 'MissingSpace' );
+				$phpcsFile->addError('Missing space after return type', $colonPtr, 'MissingSpace');
 			}
 		}
 

--- a/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
+++ b/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
@@ -53,6 +53,16 @@ class TypeHintSniff implements Sniff {
 		$returnTypePtr = $helper->getNextReturnTypePtr($phpcsFile, $stackPtr);
 		$returnType = $tokens[$returnTypePtr];
 
+		$colonPtr = $phpcsFile->findNext(T_COLON, $stackPtr, $startOfFunctionPtr);
+		if ($colonPtr) {
+			if ($tokens[$colonPtr - 1]['type'] !== 'T_CLOSE_PARENTHESIS') {
+				$phpcsFile->addError( 'Return type colon should be right after closing function parenthesis', $colonPtr, 'ExtraSpace' );
+			}
+			if ($tokens[$colonPtr + 1]['type'] !== 'T_WHITESPACE') {
+				$phpcsFile->addError( 'No space after return type', $colonPtr, 'MissingSpace' );
+			}
+		}
+
 		$nonVoidReturnCount = 0;
 		$voidReturnCount = 0;
 		$scopeClosers = [];

--- a/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
+++ b/NeutronStandard/Sniffs/Functions/TypeHintSniff.php
@@ -56,7 +56,11 @@ class TypeHintSniff implements Sniff {
 		$colonPtr = $phpcsFile->findNext(T_COLON, $stackPtr, $startOfFunctionPtr);
 		if ($colonPtr) {
 			if ($tokens[$colonPtr - 1]['type'] !== 'T_CLOSE_PARENTHESIS') {
-				$phpcsFile->addError('Return type colon should be right after closing function parenthesis', $colonPtr, 'ExtraSpace');
+				$phpcsFile->addError(
+					'Return type colon should be right after closing function parenthesis',
+					$colonPtr,
+					'ExtraSpace'
+				);
 			}
 			if ($tokens[$colonPtr + 1]['type'] !== 'T_WHITESPACE') {
 				$phpcsFile->addError('Missing space before return type', $colonPtr, 'MissingSpace');

--- a/tests/Sniffs/Functions/ClosureFixture.php
+++ b/tests/Sniffs/Functions/ClosureFixture.php
@@ -21,23 +21,30 @@ class MyClass {
 		};
 	}
 
-	// Next line should warn about type hint spacing
 	public function hasClosureWithReturnAndWrongSpacing() {
+		// Next line should warn about type hint spacing
 		$myFunc = function () : bool {
 			return true;
 		};
 	}
 
-	// Next line should warn about type hint spacing
 	public function hasClosureWithReturnAndWrongSpacing2() {
-		$myFunc = function () :bool{
+		// Next line should warn about type hint spacing
+		$myFunc = function () :bool {
 			return true;
 		};
 	}
 
-	// Next line should be okay
+	public function hasClosureWithReturnAndWrongSpacing3() {
+		// Next line should warn about type hint spacing
+		$myFunc = function (): bool{
+			return true;
+		};
+	}
+
 	public function hasClosureWithReturnAndOptionalReturnType() {
-		$myFunc = function (): ?bool{
+		// Next line should be okay
+		$myFunc = function (): ?bool {
 			return true;
 		};
 	}

--- a/tests/Sniffs/Functions/ClosureFixture.php
+++ b/tests/Sniffs/Functions/ClosureFixture.php
@@ -16,7 +16,28 @@ class MyClass {
 	}
 
 	public function hasClosureWithReturn() {
+		$myFunc = function (): bool {
+			return true;
+		};
+	}
+
+	// Next line should warn about type hint spacing
+	public function hasClosureWithReturnAndWrongSpacing() {
 		$myFunc = function () : bool {
+			return true;
+		};
+	}
+
+	// Next line should warn about type hint spacing
+	public function hasClosureWithReturnAndWrongSpacing2() {
+		$myFunc = function () :bool{
+			return true;
+		};
+	}
+
+	// Next line should be okay
+	public function hasClosureWithReturnAndOptionalReturnType() {
+		$myFunc = function (): ?bool{
 			return true;
 		};
 	}

--- a/tests/Sniffs/Functions/FunctionsFixture.php
+++ b/tests/Sniffs/Functions/FunctionsFixture.php
@@ -191,6 +191,18 @@ abstract class MyClass {
 		'something';
 	}
 
+	public function hasIncorrectTypeHintSpacing() : void {
+		'something else';
+	}
+
+	public function hasIncorrectTypeHintSpacingToo() :void {
+		'anything';
+	}
+
+	public function hasIncorrectTypeHintSpacingThree(): void{
+		'other thing';
+	}
+
 	abstract public function abstractFunctionWithReturn(): int;
 
 	// The next line should report an invalid void return

--- a/tests/Sniffs/Functions/FunctionsFixture.php
+++ b/tests/Sniffs/Functions/FunctionsFixture.php
@@ -135,7 +135,7 @@ abstract class MyClass {
 	}
 
 	// Next line should warn about unused type hint
-	public function hasReturnHintButNoReturn() : string {
+	public function hasReturnHintButNoReturn(): string {
 	}
 
 	public function hasNoReturn(string $arg1, string $arg2) {

--- a/tests/Sniffs/Functions/TypeHintSniffTest.php
+++ b/tests/Sniffs/Functions/TypeHintSniffTest.php
@@ -15,7 +15,7 @@ class TypeHintSniffTest extends TestCase {
 		$phpcsFile->process();
 		$errorLines = $helper->getErrorLineNumbersFromFile($phpcsFile);
 		$warningLines = $helper->getWarningLineNumbersFromFile($phpcsFile);
-		$this->assertEquals([138], $errorLines);
+		$this->assertEquals([138, 194, 198, 202], $errorLines);
 		$this->assertEquals([118, 123, 128, 133], $warningLines);
 	}
 
@@ -40,7 +40,7 @@ class TypeHintSniffTest extends TestCase {
 		$warningLines = $helper->getWarningLineNumbersFromFile($phpcsFile);
 		$errorLines = $helper->getErrorLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([5, 11], $warningLines);
-		$this->assertEquals([26, 33], $errorLines);
+		$this->assertEquals([26, 33, 40], $errorLines);
 	}
 
 	public function testTypeHintSniffWithInterface() {

--- a/tests/Sniffs/Functions/TypeHintSniffTest.php
+++ b/tests/Sniffs/Functions/TypeHintSniffTest.php
@@ -40,7 +40,7 @@ class TypeHintSniffTest extends TestCase {
 		$warningLines = $helper->getWarningLineNumbersFromFile($phpcsFile);
 		$errorLines = $helper->getErrorLineNumbersFromFile($phpcsFile);
 		$this->assertEquals([5, 11], $warningLines);
-		$this->assertEquals([], $errorLines);
+		$this->assertEquals([26, 33], $errorLines);
 	}
 
 	public function testTypeHintSniffWithInterface() {


### PR DESCRIPTION
We noticed that there is WPCS rule for spacing around the colon in function return types. We had some discrepancies in how we were spacing the colon and since most of our team is using the Neutron coding standards I decided we should implement that check too.

The idea is that there should be no space between the function declaration and the colon, but then there should be a space between the colon and the return type.

So basically:
```
// valid
function(): bool {...
// invalid
function() : bool {...
// invalid
function() :bool {...
```

see the "return type" example here - https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#space-usage