### PR TITLE
Support PHP 8.0 and modernize TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,37 @@
-language: php
+# TravisCI configuration for Automattic/phpcs-neutron-standard
 
-matrix:
-  include:
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
-    - php: 7.4
-  fast_finish: true
+if: "branch = master"
 
+language: "php"
 os:
-  - linux
+  - "linux"
+dist: "xenial"
 
-sudo: false
+php:
+  - php: "7.4"
+  - php: "7.3"
+  - php: "7.2"
+  - php: "7.1"
+  - php: "7.0"
+
+jobs:
+  fast_finish: true
+  include:
+    - php: "8.0"
+      script:
+        - "composer update --ignore-platform-reqs"
+        - "composer test"
+        - "composer lint"
 
 cache:
   directories:
-    - $HOME/.composer/cache
+    - "$HOME/.composer/cache"
 
 script:
-  - composer validate --strict
-  - composer install
-  - composer test
-  - composer lint
+  - "composer validate --strict"
+  - "composer update"
+  - "composer test"
+  - "composer lint"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ os:
 dist: "xenial"
 
 php:
-  - php: "7.4"
-  - php: "7.3"
-  - php: "7.2"
-  - php: "7.1"
-  - php: "7.0"
+  - "7.4"
+  - "7.3"
+  - "7.2"
+  - "7.1"
+  - "7.0"
 
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
 dist: "xenial"
 
 php:
+  - "8.0"
   - "7.4"
   - "7.3"
   - "7.2"
@@ -16,12 +17,6 @@ php:
 
 jobs:
   fast_finish: true
-  include:
-    - php: "8.0"
-      script:
-        - "composer update --ignore-platform-reqs"
-        - "composer test"
-        - "composer lint"
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
         }
     },
     "require": {
-        "php": "^7.0",
+        "php": "^7.0 || ^8.0",
         "squizlabs/php_codesniffer": "^3.3.0"
     },
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.0.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6 || ^0.7",
         "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0"
     }
 }


### PR DESCRIPTION
- chronological order
- add PHP 8
- run on newer Ubuntu
- YAML strings

@sirbrillig 👀 