### PR TITLE
Add "static analysis" Composer keyword

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "automattic/phpcs-neutron-standard",
     "description": "A set of phpcs sniffs for modern php development.",
     "type": "phpcodesniffer-standard",
+    "keywords" : [ "phpcs", "static analysis" ],
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
As per https://getcomposer.org/doc/04-schema.md#keywords by including "static analysis" as a keyword in the `composer.json` file, Composer 2.4.0-RC1 and later will prompt users if the package is installed with `composer require` instead of `composer require --dev`. See https://github.com/composer/composer/pull/10960 for more info.

The "phpcs" keyword is to match other coding-standards packages.